### PR TITLE
Read in complex 2dseq

### DIFF
--- a/brukerapi/config/properties_2dseq_core.json
+++ b/brukerapi/config/properties_2dseq_core.json
@@ -151,6 +151,12 @@
       "conditions": []
     }
   ],
+  "reco_type": [
+    {
+    "cmd": "#VisuCoreFrameType",
+    "conditions": []
+    }
+  ],
   "dim_type": [
     {
       "cmd": "#VisuCoreDimDesc.list + ['spatial',] + #VisuFGOrderDesc.sub_list(1)",

--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -515,6 +515,7 @@ class Dataset:
             self._data = DataRandomAccess(self)
         else:
             self._data = self._read_data()
+            print("self._data.shape = " + str(self._data.shape))
 
     def unload_data(self):
         """
@@ -524,6 +525,8 @@ class Dataset:
 
     def _read_data(self):
         data = self._read_binary_file(self.path, self.numpy_dtype, self.shape_storage)
+        print("self.shape_storage = " + str(self.shape_storage))
+        print("data.shape = " + str(data.shape))
         return self._schema.deserialize(data, self._schema.layouts)
 
     def _read_binary_file(self, path, dtype, shape):

--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -515,7 +515,6 @@ class Dataset:
             self._data = DataRandomAccess(self)
         else:
             self._data = self._read_data()
-            print("self._data.shape = " + str(self._data.shape))
 
     def unload_data(self):
         """
@@ -525,8 +524,6 @@ class Dataset:
 
     def _read_data(self):
         data = self._read_binary_file(self.path, self.numpy_dtype, self.shape_storage)
-        print("self.shape_storage = " + str(self.shape_storage))
-        print("data.shape = " + str(data.shape))
         return self._schema.deserialize(data, self._schema.layouts)
 
     def _read_binary_file(self, path, dtype, shape):

--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -558,7 +558,6 @@ class Schema2dseq(Schema):
         if self._dataset._state['scale']:
             data = self._scale_frames(data, layouts, 'FW')
         # frames -> frame_groups
-        print("deserialize --> data.shape=" + str(data.shape))
         data = self._frames_to_framegroups(data, layouts)
         if hasattr(self._dataset, 'reco_type'): 
             # complex reco:
@@ -580,7 +579,6 @@ class Schema2dseq(Schema):
                 pass
             else:
                 pass
-        print("deserialize --> data.shape=" + str(data.shape))
         return data
 
     def _scale_frames(self, data, layouts, dir):

--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -558,13 +558,14 @@ class Schema2dseq(Schema):
         if self._dataset._state['scale']:
             data = self._scale_frames(data, layouts, 'FW')
         # frames -> frame_groups
+        print("deserialize --> data.shape=" + str(data.shape))
         data = self._frames_to_framegroups(data, layouts)
         if hasattr(self._dataset, 'reco_type'): 
             # complex reco:
             if self._dataset.reco_type[0] == 'REAL_IMAGE' and self._dataset.reco_type[1] == 'IMAGINARY_IMAGE':
-                data = data[...,::2] + 1j * data[...,1::2]
+                data = np.squeeze(data[...,::2] + 1j * data[...,1::2])
             elif self._dataset.reco_type[0] == 'IMAGINARY_IMAGE' and self._dataset.reco_type[1] == 'REAL_IMAGE':
-                data = data[...,1::2] + 1j * data[...,::2]
+                data = np.squeeze(data[...,1::2] + 1j * data[...,::2])
             # real reco:
             elif self._dataset.reco_type[0] == 'REAL_IMAGE':
                 pass
@@ -579,6 +580,7 @@ class Schema2dseq(Schema):
                 pass
             else:
                 pass
+        print("deserialize --> data.shape=" + str(data.shape))
         return data
 
     def _scale_frames(self, data, layouts, dir):

--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -43,7 +43,7 @@ REQUIRED_PROPERTIES = {
         "slope",
         "offset",
         "dim_type",
-        "reco_type" # new addition so you can also load complex reco
+        "reco_type"
     ],
     "rawdata": [
         "numpy_dtype",
@@ -565,6 +565,15 @@ class Schema2dseq(Schema):
                 data = data[...,::2] + 1j * data[...,1::2]
             elif self._dataset.reco_type[0] == 'IMAGINARY_IMAGE' and self._dataset.reco_type[1] == 'REAL_IMAGE':
                 data = data[...,1::2] + 1j * data[...,::2]
+            # real reco:
+            elif self._dataset.reco_type[0] == 'REAL_IMAGE':
+                pass
+            # imaginary reco:
+            elif self._dataset.reco_type[0] == 'IMAGINARY_IMAGE':
+                pass
+            # imaginary reco:
+            elif self._dataset.reco_type[0] == 'PHASE_IMAGE':
+                pass
             # standard (magntitude) reco:
             elif self._dataset.reco_type == ['MAGNITUDE_IMAGE']:
                 pass
@@ -574,7 +583,6 @@ class Schema2dseq(Schema):
 
     def _scale_frames(self, data, layouts, dir):
         """
-        Does not work for complex data!
         :param data:
         :param layouts:
         :param dir:


### PR DESCRIPTION
A new property `reco_type` for 2dseq files was created. This now checks the VisuCoreFrameType in the visu_pars file.
Depending on the value (IMAGINARY_IMAGE + REAL_IMAGE, IMAGINARY_IMAGE, REAL_IMAGE, PHASE_IMAGE or MAGNITUDE_IMAGE (default)), in `deserialize` in the `schemas.py` and loads the data accordingly.
This means that complex reconstructed data (REAL_IMAGE AND IMAGINARY_IMAGE) will be loaded as complex data