### PR TITLE
Change description-file to description_file in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Fixes:

```
SetuptoolsDeprecationWarning: Invalid dash-separated options
  !!

          ********************************************************************************
          Usage of dash-separated 'description-file' will not be supported in future
          versions. Please use the underscore name 'description_file' instead.

          By 2023-Sep-26, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
          ********************************************************************************

  !!
```