### PR TITLE
Fix invalid and unintended regex escape sequences

### DIFF
--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -461,7 +461,7 @@ class Dataset:
 
     def _sub_parameters(self, recipe):
         # entries with property e.g. VisuFGOrderDesc.nested to self._dataset['VisuFGOrderDesc'].nested
-        for match in re.finditer('#[a-zA-Z0-9_]+\.[a-zA-Z]+', recipe):
+        for match in re.finditer(r'#[a-zA-Z0-9_]+\.[a-zA-Z]+', recipe):
             m = re.match('#[a-zA-Z0-9_]+', match.group())
             recipe = recipe.replace(m.group(),"self['{}']".format(m.group()[1:]))
         # entries without property e.g. VisuFGOrderDesc to self._dataset['VisuFGOrderDesc'].value

--- a/brukerapi/jcampdx.py
+++ b/brukerapi/jcampdx.py
@@ -8,12 +8,12 @@ import json
 
 SUPPORTED_VERSIONS = ['4.24', '5.0', '5.00 Bruker JCAMP library', '5.00 BRUKER JCAMP library', '5.01']
 GRAMMAR = {
-        'COMMENT_LINE' : '\\$\\$[^\n]*\n',
+        'COMMENT_LINE' : r'\$\$[^\n]*\n',
         'PARAMETER': '##',
         'USER_DEFINED' : r'\$',
-        'TRAILING_EOL' : '\n$',
+        'TRAILING_EOL' : r'\n$',
         'DATA_LABEL' : r'\(XY..XY\)',
-        'DATA_DELIMETERS':', |\n',
+        'DATA_DELIMETERS': r', |\n',
         'SIZE_BRACKET': r'^\([^\(\)<>]*\)(?!$)',
         'LIST_DELIMETER': ', ',
         'EQUAL_SIGN': '=',
@@ -203,7 +203,7 @@ class GenericParameter(Parameter):
     @property
     def value(self, **kwargs):
 
-        val_str = re.sub('\n', '', self.val_str)
+        val_str = re.sub(r'\n', '', self.val_str)
 
         # unwrap wrapped list
         if re.match(r'@[0-9]*\*',val_str) is not None:
@@ -318,7 +318,7 @@ class GenericParameter(Parameter):
     @classmethod
     def parse_value(cls, val_str, size_bracket=None):
         # remove \n
-        val_str = re.sub('\n','', val_str)
+        val_str = re.sub(r'\n','', val_str)
 
         # sharp string
         if val_str.startswith('<') and val_str.endswith('>'):
@@ -903,7 +903,7 @@ class JCAMPDX(object):
 
     @classmethod
     def wrap_lines(cls, line):
-        line_wraps = re.split('\n', line)
+        line_wraps = re.split(r'\n', line)
         tail = line_wraps[-1]
 
         tail_bits = re.split(r'\s', tail)

--- a/brukerapi/jcampdx.py
+++ b/brukerapi/jcampdx.py
@@ -8,18 +8,18 @@ import json
 
 SUPPORTED_VERSIONS = ['4.24', '5.0', '5.00 Bruker JCAMP library', '5.00 BRUKER JCAMP library', '5.01']
 GRAMMAR = {
-        'COMMENT_LINE' : '\$\$[^\n]*\n',
+        'COMMENT_LINE' : '\\$\\$[^\n]*\n',
         'PARAMETER': '##',
-        'USER_DEFINED' : '\$',
+        'USER_DEFINED' : r'\$',
         'TRAILING_EOL' : '\n$',
-        'DATA_LABEL' : '\(XY..XY\)',
+        'DATA_LABEL' : r'\(XY..XY\)',
         'DATA_DELIMETERS':', |\n',
-        'SIZE_BRACKET': '^\([^\(\)<>]*\)(?!$)',
+        'SIZE_BRACKET': r'^\([^\(\)<>]*\)(?!$)',
         'LIST_DELIMETER': ', ',
         'EQUAL_SIGN': '=',
-        'SINGLE_NUMBER':'-?[\d.]+(?:e[+-]?\d+)?',
-        'PARALLEL_BRACKET': '\) ',
-        'GEO_OBJ': '\(\(\([\s\S]*\)[\s\S]*\)[\s\S]*\)',
+        'SINGLE_NUMBER': r'-?[\d.]+(?:e[+-]?\d+)?',
+        'PARALLEL_BRACKET': r'\) ',
+        'GEO_OBJ': r'\(\(\([\s\S]*\)[\s\S]*\)[\s\S]*\)',
         'HEADER':'TITLE|JCAMPDX|JCAMP-DX|DATA TYPE|DATATYPE|ORIGIN|OWNER',
         'VERSION_TITLE':'JCAMPDX|JCAMP-DX'
     }
@@ -107,7 +107,7 @@ class Parameter(object):
 
     @property
     def key(self):
-        return re.sub('##', '', re.sub('\$', '', self.key_str)).rstrip()
+        return re.sub('##', '', re.sub(r'\$', '', self.key_str)).rstrip()
 
     @key.setter
     def key(self, key):
@@ -206,7 +206,7 @@ class GenericParameter(Parameter):
         val_str = re.sub('\n', '', self.val_str)
 
         # unwrap wrapped list
-        if re.match('@[0-9]*\*',val_str) is not None:
+        if re.match(r'@[0-9]*\*',val_str) is not None:
             val_str = self._unwrap_list(val_str)
 
         val_str_list = GenericParameter.split_parallel_lists(val_str)
@@ -455,12 +455,12 @@ class GenericParameter(Parameter):
 
     def _unwrap_list(self, val_str):
 
-        while re.search('@[0-9]*\*\(\d*\.?\d*\)', val_str):
-            match = re.search('@[0-9]*\*\(\d*\.?\d*\)', val_str)
+        while re.search(r'@[0-9]*\*\(\d*\.?\d*\)', val_str):
+            match = re.search(r'@[0-9]*\*\(\d*\.?\d*\)', val_str)
             left = val_str[0:match.start()]
             right = val_str[match.end():]
             sub = val_str[match.start():match.end()]
-            size, value = re.split('\*', sub)
+            size, value = re.split(r'\*', sub)
             size = int(size[1:])
             middle = ''
             for i in range(size):
@@ -506,7 +506,7 @@ class GeometryParameter(Parameter):
     #     :return: 4x4 3D Affine Transformation Matrix
     #     """
     #     # TODO support for multiple slice packages
-    #     match = re.match('\(\(\([^\)]*\)', self.val_str)
+    #     match = re.match(r'\(\(\([^\)]*\)', self.val_str)
     #     affine_str = self.val_str[match.start() + 3: match.end() - 1]
     #     orient, shift = affine_str.split(', ')
     #
@@ -799,7 +799,7 @@ class JCAMPDX(object):
             except:
                 raise InvalidJcampdxFile(path)
 
-        match = re.search('##{}[^\#\$]+|##\${}[^\#\$]+'.format(key,key), content)
+        match = re.search(r'##{}[^\#\$]+|##\${}[^\#\$]+'.format(key,key), content)
 
         if match == None:
             raise ParameterNotFound(key, path)
@@ -906,7 +906,7 @@ class JCAMPDX(object):
         line_wraps = re.split('\n', line)
         tail = line_wraps[-1]
 
-        tail_bits = re.split('\s', tail)
+        tail_bits = re.split(r'\s', tail)
 
         lines = 1
         tail = ''


### PR DESCRIPTION
Fixes a pile of `SyntaxWarning`s on Python 3.12.