### PR TITLE
Explicitly distribute brukerapi.config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='brukerapi',
       author_email='tomaspsorn@isibrno.cz',
       url='https://github.com/isi-nmr/brukerapi-python',
       download_url='https://github.com/isi-nmr/brukerapi-python/releases/latest',
-      packages=['brukerapi',],
+      packages=['brukerapi', 'brukerapi.config'],
       install_requires=['numpy','pyyaml'],
       entry_points={
             "console_scripts": [


### PR DESCRIPTION
While `brukerapi.config` is already present in distributed wheels, the following warning appears while building them:

```
 /usr/lib/python3.12/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'brukerapi.config' is absent from the `packages` configuration.
  !!
          ********************************************************************************
          ############################
          # Package would be ignored #
          ############################
          Python recognizes 'brukerapi.config' as an importable package[^1],
          but it is absent from setuptools' `packages` configuration.
          This leads to an ambiguous overall configuration. If you want to distribute this
          package, please make sure that 'brukerapi.config' is explicitly added
          to the `packages` configuration field.
          Alternatively, you can also rely on setuptools' discovery methods
          (for example by using `find_namespace_packages(...)`/`find_namespace:`
          instead of `find_packages(...)`/`find:`).
          You can read more about "package discovery" on setuptools documentation page:
          - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html
          If you don't want 'brukerapi.config' to be distributed and are
          already explicitly excluding 'brukerapi.config' via
          `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
          you can try to use `exclude_package_data`, or `include-package-data=False` in
          combination with a more fine grained `package-data` configuration.
          You can read more about "package data files" on setuptools documentation page:
          - https://setuptools.pypa.io/en/latest/userguide/datafiles.html
          [^1]: For Python, any directory (with suitable naming) can be imported,
                even if it does not contain any `.py` files.
                On the other hand, currently there is no concept of package data
                directory, all directories are treated like packages.
          ********************************************************************************
  !!
    check.warn(importable)
```

This PR resolves the ambiguity and removes the warning by explicitly adding `brukerapi.config` to the `packages` list.