### PR TITLE
Fix VisuCoreWordType spelling for 8-bit unsigned 2dseq (_8BIT_UNSGN_INT)

### DIFF
--- a/brukerapi/config/properties_2dseq_core.json
+++ b/brukerapi/config/properties_2dseq_core.json
@@ -30,7 +30,7 @@
     {
         "cmd": "np.dtype('uint8').newbyteorder('<')",
         "conditions": [
-          ["#VisuCoreWordType",["_8BIT_USGN_INT"]],
+          ["#VisuCoreWordType",["_8BIT_UNSGN_INT"]],
           ["#VisuCoreByteOrder",["littleEndian"]]
         ]
     },
@@ -58,7 +58,7 @@
     {
         "cmd": "np.dtype('uint8').newbyteorder('>')",
         "conditions": [
-          ["#VisuCoreWordType",["_8BIT_USGN_INT"]],
+          ["#VisuCoreWordType",["_8BIT_UNSGN_INT"]],
           ["#VisuCoreByteOrder",["bigEndian"]]
         ]
     }


### PR DESCRIPTION
## Problem

`config/properties_2dseq_core.json` selects the numpy dtype for 8-bit unsigned `2dseq` data by matching `VisuCoreWordType == "_8BIT_USGN_INT"`. That spelling is wrong — ParaVision spells the enum **`_8BIT_UNSGN_INT`** (with the `N`):

- `RECO_WORDTYPE` in `prog/include/recotyp.h`: `{ _32BIT_SGN_INT, _16BIT_SGN_INT, _8BIT_UNSGN_INT, _32BIT_FLOAT }`
- real `visu_pars` files store `##$VisuCoreWordType=_8BIT_UNSGN_INT`

Because the stored value never matches `_8BIT_USGN_INT`, no `numpy_dtype` branch fires, the property is never set, and `Schema.__init__` raises `MissingProperty("numpy_dtype")` — an 8-bit-unsigned `2dseq` cannot be loaded. The `2dseq` `numpy_dtype` selection has no `ACQ_sw_version` gate, so the failure is version-independent and depends only on `VisuCoreWordType`.

## Fix

Correct both occurrences (little- and big-endian branches) to `_8BIT_UNSGN_INT`. The signed 16/32-bit and float branches were already correct.

## Public dataset that reproduces it

The **MRIReco.jl** Bruker test data contains a reconstruction stored as 8-bit unsigned:

- Download (public, no login): https://media.tuhh.de/ibi/mrireco/MRIRecoTestData.tar.gz &nbsp;(`sha256 c5a421aab7f3ea3fb20c469704db33c17b659861d9d77dbd29e353db2d5c8fc7`)
- Inside the archive: `BrukerFile/2D_FLASH/pdata/7/` — its `visu_pars` has `##$VisuCoreWordType=_8BIT_UNSGN_INT` and `##$VisuCoreByteOrder=littleEndian`.

```python
from brukerapi.dataset import Dataset
Dataset("<extracted>/BrukerFile/2D_FLASH/pdata/7/2dseq")
# before this change: MissingProperty: numpy_dtype
# after:  loads as a uint8 array
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
