### PR TITLE
 `Dataset` type detection has no subtype allow-list — `.npz`/`.json` …

### DIFF
--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -25,7 +25,7 @@ from .exceptions import (
     UnsuportedDatasetType,
 )
 from .jcampdx import JCAMPDX
-from .schemas import Schema2dseq, SchemaFid, SchemaRawdata, SchemaTraj
+from .schemas import Schema2dseq, SchemaFid, SchemaFidCompanion, SchemaRawdata, SchemaTraj
 
 LOAD_STAGES = {
     "empty": 0,
@@ -117,6 +117,15 @@ RELATIVE_PATHS = {
     },
 }
 
+SUPPORTED_SUBTYPES = {
+    "fid": {""},
+    "fid_proc": {"64"},
+    "2dseq": {""},
+    "traj": {""},
+    "rawdata": {"Navigator"},
+}
+FID_COMPANION_SUBTYPES = {"navFid", "orig", "spiral"}
+
 
 class Dataset:
     """
@@ -195,6 +204,8 @@ class Dataset:
 
         if self.type not in DEFAULT_STATES:
             raise UnsuportedDatasetType(self.type)
+        if not self._is_supported_subtype() and not (state.get("_auxiliary") and self.type == "fid" and self.subtype in FID_COMPANION_SUBTYPES):
+            raise UnsuportedDatasetType(self.path.name)
 
         # set
         self._set_state(state)
@@ -204,6 +215,11 @@ class Dataset:
 
         # load data if the load kwarg is true
         self.load()
+
+    def _is_supported_subtype(self):
+        if self.type == "rawdata" and re.fullmatch(r"job\d+", self.subtype):
+            return True
+        return self.subtype in SUPPORTED_SUBTYPES[self.type]
 
     def __enter__(self):
         self._state["load"] = LOAD_STAGES["all"]
@@ -291,6 +307,7 @@ class Dataset:
         self.load_schema()
         self.load_data()
         self.load_traj()
+        self.load_fid_companions()
 
     def unload(self):
         """
@@ -302,6 +319,7 @@ class Dataset:
         self.unload_schema()
         self.unload_data()
         self.unload_traj()
+        self.unload_fid_companions()
 
     """
     PARAMETERS
@@ -663,6 +681,32 @@ class Dataset:
         self._traj = None
 
     """
+    FID COMPANIONS
+    """
+
+    def load_fid_companions(self):
+        self._fid_companions = {}
+        if self.type != "fid" or self.subtype or self._state.get("_auxiliary"):
+            return
+
+        for subtype in sorted(FID_COMPANION_SUBTYPES):
+            path = self.path.with_suffix(f".{subtype}")
+            if not path.exists():
+                continue
+
+            companion = Dataset(path, load=LOAD_STAGES["empty"], _auxiliary=True)
+            companion._parameters = self.parameters
+            companion.numpy_dtype = self.numpy_dtype
+            companion.shape_storage = (path.stat().st_size // self.numpy_dtype.itemsize,)
+            companion.dim_type = ["sample"]
+            companion._schema = SchemaFidCompanion(companion)
+            companion.load_data()
+            self._fid_companions[subtype] = companion
+
+    def unload_fid_companions(self):
+        self._fid_companions = {}
+
+    """
     EXPORT INTERFACE
     """
 
@@ -756,7 +800,7 @@ class Dataset:
             props = list(vars(self).keys())
 
         # list of Dataset properties to be excluded from the export
-        reserved = ["_parameters", "path", "_data", "_traj", "_state", "_schema", "random_access", "study_id", "exp_id", "proc_id", "subj_id", "_properties"]
+        reserved = ["_parameters", "path", "_data", "_traj", "_fid_companions", "_state", "_schema", "random_access", "study_id", "exp_id", "proc_id", "subj_id", "_properties"]
         props = list(set(props) - set(reserved))
 
         properties = {}
@@ -828,6 +872,11 @@ class Dataset:
         if self._traj is not None:
             return self._traj.data
         raise TrajNotLoaded
+
+    @property
+    def fid_companions(self):
+        """Auxiliary ``fid.<subtype>`` datasets keyed by subtype."""
+        return self._fid_companions.copy()
 
     @property
     def parameters(self):

--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -423,6 +423,26 @@ class SchemaFid(Schema):
         return index
 
 
+class SchemaFidCompanion:
+    """One-dimensional complex view of an auxiliary ``fid.<subtype>`` file."""
+
+    def __init__(self, dataset):
+        self._dataset = dataset
+
+    @property
+    def layouts(self):
+        return {"storage": self._dataset.shape_storage}
+
+    def deserialize(self, data, layouts):
+        return data[0::2] + 1j * data[1::2]
+
+    def serialize(self, data, layouts):
+        serialized = np.empty(data.size * 2, dtype=self._dataset.numpy_dtype)
+        serialized[0::2] = np.real(data)
+        serialized[1::2] = np.imag(data)
+        return serialized
+
+
 class SchemaTraj(Schema):
     @property
     def layouts(self):

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import os
+import re
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -21,6 +22,87 @@ def test_unsupported_dataset_type(tmp_path):
 
     with pytest.raises(UnsuportedDatasetType, match="Dataset type: unsupported is not supported"):
         Dataset(path)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "fid.npz",
+        "fid.json",
+        "fid.navFid",
+        "fid.orig",
+        "fid.spiral",
+        "2dseq.npz",
+        "2dseq.json",
+        "traj.npy",
+        "rawdata.zip",
+    ],
+)
+def test_dataset_rejects_nonprimary_and_unknown_subtypes(tmp_path, name):
+    path = tmp_path / name
+    path.touch()
+
+    with pytest.raises(UnsuportedDatasetType, match=rf"Dataset type: {re.escape(name)} is not supported"):
+        Dataset(path)
+
+
+@pytest.mark.parametrize(
+    ("name", "dataset_type", "subtype"),
+    [
+        ("fid", "fid", ""),
+        ("fid_proc.64", "fid_proc", "64"),
+        ("2dseq", "2dseq", ""),
+        ("traj", "traj", ""),
+        ("rawdata.job12", "rawdata", "job12"),
+        ("rawdata.Navigator", "rawdata", "Navigator"),
+    ],
+)
+def test_dataset_accepts_known_primary_binary_subtypes(tmp_path, name, dataset_type, subtype):
+    path = tmp_path / name
+    path.touch()
+
+    dataset = Dataset(path, load=LOAD_STAGES["empty"])
+
+    assert dataset.type == dataset_type
+    assert dataset.subtype == subtype
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "test/test_data/PV51/0.2H2/35/fid.navFid",
+        "test/test_data/PV51/0.2H2/35/fid.orig",
+        "test/test_data/PV51/0.2H2/19/fid.spiral",
+    ],
+)
+def test_fid_companion_files_are_not_loaded_as_primary_datasets(path):
+    if not Path(path).is_file():
+        pytest.skip(f"{path} is not available")
+
+    with pytest.raises(UnsuportedDatasetType, match=rf"Dataset type: {re.escape(Path(path).name)} is not supported"):
+        Dataset(path)
+
+
+@pytest.mark.parametrize(
+    ("fid_path", "subtypes"),
+    [
+        ("test/test_data/PV51/0.2H2/19/fid", {"spiral"}),
+        ("test/test_data/PV51/0.2H2/35/fid", {"navFid", "orig"}),
+    ],
+)
+def test_fid_companions_load_as_auxiliary_subdatasets(fid_path, subtypes):
+    if not Path(fid_path).is_file():
+        pytest.skip(f"{fid_path} is not available")
+
+    dataset = Dataset(fid_path)
+
+    assert set(dataset.fid_companions) == subtypes
+    for subtype, companion in dataset.fid_companions.items():
+        assert isinstance(companion, Dataset)
+        assert companion.path == Path(fid_path).with_suffix(f".{subtype}")
+        assert companion.data.ndim == 1
+        assert np.iscomplexobj(companion.data)
+        assert companion.data.size * 2 * companion.numpy_dtype.itemsize == companion.path.stat().st_size
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
…sidecars mis-detected as datasets

 Fixes #56

 fid method-companion files (`fid.spiral`/`fid.navFid`/`fid.orig`) loaded as primary `fid`
 Fixes #57