### PR TITLE
`Folder.__getattr__` raises `KeyError` instead of `AttributeError` — …

### DIFF
--- a/brukerapi/folders.py
+++ b/brukerapi/folders.py
@@ -99,17 +99,17 @@ class Folder:
         :param name: Name of Dataset, JCAMPDX, or Folder
         :return:
         """
-        if hasattr(self, "_children_map"):
-            try:
-                return self._children_map[name]
-            except KeyError:
-                pass
-        else:
+        children_map = self.__dict__.get("_children_map")
+        if children_map is None:
+            if "children" not in self.__dict__:
+                raise AttributeError(name)
             self.make_children_map()
-            if name in self._children_map:
-                return self._children_map[name]
+            children_map = self._children_map
 
-        raise KeyError(f"Child '{name}' not found in {self.path}")
+        try:
+            return children_map[name]
+        except KeyError:
+            raise AttributeError(name) from None
 
     def __getitem__(self, name):
         """Access individual files in folder, dict style. :obj:`.Dataset` and :obj:`.JCAMPDX` instances are not loaded, to access the
@@ -127,7 +127,10 @@ class Folder:
         :param name: Name of :obj:`.Dataset`, :obj:`.JCAMPDX`, or :obj:`.Folder` object
         :return:
         """
-        return self.__getattr__(name)
+        try:
+            return self.__getattr__(name)
+        except AttributeError:
+            raise KeyError(f"Child '{name}' not found in {self.path}") from None
 
     def query(self, query):
         """Query each dataset in the folder recursively.

--- a/test/test_folders.py
+++ b/test/test_folders.py
@@ -1,3 +1,5 @@
+import copy
+import pickle
 from pathlib import Path
 
 import pytest
@@ -6,6 +8,25 @@ from brukerapi.dataset import Dataset
 from brukerapi.folders import Folder, Processing, Study
 
 PV51_STUDY_PATH = Path("test/test_data/PV51/0.2H2")
+
+
+def test_folder_attribute_miss_supports_hasattr_deepcopy_and_pickle(tmp_path):
+    (tmp_path / "child").mkdir()
+    folder = Folder(tmp_path, recursive=False)
+
+    assert not hasattr(folder, "missing")
+    with pytest.raises(AttributeError, match="missing"):
+        _ = folder.missing
+    with pytest.raises(KeyError, match="Child 'missing' not found"):
+        _ = folder["missing"]
+
+    copied = copy.deepcopy(folder)
+    restored = pickle.loads(pickle.dumps(folder))
+
+    assert copied.path == folder.path
+    assert restored.path == folder.path
+    assert [child.path.name for child in copied.children] == [child.path.name for child in folder.children]
+    assert [child.path.name for child in restored.children] == [child.path.name for child in folder.children]
 
 
 def test_folder_traversal_skips_processed_spectra(tmp_path):


### PR DESCRIPTION
…breaks `hasattr`/`deepcopy`/pickle

Fixes #60