### PR TITLE
`_read_binary_file`: every size mismatch reported as "dimension misma…

### DIFF
--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -652,10 +652,29 @@ class Dataset:
         1D ndarray containing the full data vector
         """
 
-        try:
-            assert os.stat(str(path)).st_size == np.prod(shape) * dtype.itemsize
-        except AssertionError:
-            raise InvalidDataset("Invalid dataset, dimension mismatch") from AssertionError
+        actual_bytes = os.stat(path).st_size
+        expected_bytes = int(np.prod(shape) * dtype.itemsize)
+        if actual_bytes != expected_bytes:
+            with Path(path).open("rb") as binary:
+                signature = binary.read(42)
+
+            if signature == b"version https://git-lfs.github.com/spec/v1":
+                raise InvalidDataset(f"Invalid dataset, Git LFS pointer stub at {path}; fetch the binary file content")
+
+            if actual_bytes == 0:
+                raise InvalidDataset(f"Invalid dataset, empty binary file at {path}; expected {expected_bytes} bytes for shape {tuple(shape)} and dtype {dtype}")
+
+            frame_shape = tuple(shape[:-1]) if len(shape) > 1 else tuple(shape)
+            frame_bytes = int(np.prod(frame_shape) * dtype.itemsize)
+            if actual_bytes < frame_bytes:
+                raise InvalidDataset(
+                    f"Invalid dataset, empty or stub file at {path}: got {actual_bytes} bytes, less than one frame ({frame_bytes} bytes); "
+                    f"expected {expected_bytes} bytes for shape {tuple(shape)} and dtype {dtype}"
+                )
+
+            raise InvalidDataset(
+                f"Invalid dataset size at {path}: expected {expected_bytes} bytes for shape {tuple(shape)} and dtype {dtype}, got {actual_bytes} bytes"
+            )
 
         return np.array(np.memmap(path, dtype=dtype, shape=shape, order="F")[:])
 

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -277,6 +277,28 @@ def test_phase_encode_reorder_reports_axis_length_mismatch():
         dataset._schema._reorder_fid_lines(data)
 
 
+@pytest.mark.parametrize(
+    ("content", "message"),
+    [
+        (b"", r"empty binary file .* expected 24 bytes for shape \(4, 3\) and dtype int16"),
+        (b"1234", r"empty or stub file .* got 4 bytes, less than one frame \(8 bytes\)"),
+        (b"123456789012", r"expected 24 bytes for shape \(4, 3\) and dtype int16, got 12 bytes"),
+        (
+            b"version https://git-lfs.github.com/spec/v1\noid sha256:abc\nsize 24\n",
+            r"Git LFS pointer stub .* fetch the binary file content",
+        ),
+    ],
+    ids=["empty", "stub", "truncated", "git-lfs"],
+)
+def test_binary_size_mismatch_reports_specific_cause(tmp_path, content, message):
+    path = tmp_path / "2dseq"
+    path.write_bytes(content)
+    dataset = Dataset(path, load=LOAD_STAGES["empty"])
+
+    with pytest.raises(InvalidDataset, match=message):
+        dataset._read_binary_file(path, np.dtype("int16"), (4, 3))
+
+
 @pytest.mark.skipif(not PV51_STUDY_PATH.is_dir(), reason="PV51 test data is not available")
 def test_report_default_directory_and_cli_file_outputs(tmp_path):
     source = Dataset(PV51_STUDY_PATH / "10" / "fid")


### PR DESCRIPTION
…tch" (stub/empty/truncated indistinguishable)

Fixes #64