### PR TITLE
`_reorder_fid_lines` no-op guard compares argsort indices to raw `PVM…

### DIFF
--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -209,7 +209,7 @@ class SchemaFid(Schema):
                 f"phase-encode reorder length {len(PVM_EncSteps1_sorted)} does not match k-space axis length {data.shape[1]} for scheme {self._dataset.scheme_id}"
             )
 
-        if np.array_equal(PVM_EncSteps1_sorted, PVM_EncSteps1):
+        if np.array_equal(PVM_EncSteps1_sorted, np.arange(len(PVM_EncSteps1_sorted))):
             return data
 
         for index in np.ndindex(data.shape[2:]):

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -312,6 +312,19 @@ def test_zte_uses_dedicated_fid_layout_branches():
 
 
 @pytest.mark.skipif(not PV51_STUDY_PATH.is_dir(), reason="PV51 test data is not available")
+def test_monotonic_phase_encode_steps_skip_reordering():
+    dataset = Dataset(PV51_STUDY_PATH / "10" / "fid")
+    dataset["PVM_EncSteps1"].val_str = "10 20 30"
+    dataset["PVM_EncSteps1"].size = (3,)
+    data = np.arange(12).reshape(4, 3)
+    data.flags.writeable = False
+
+    reordered = dataset._schema._reorder_fid_lines(data)
+
+    assert reordered is data
+
+
+@pytest.mark.skipif(not PV51_STUDY_PATH.is_dir(), reason="PV51 test data is not available")
 def test_report_default_directory_and_cli_file_outputs(tmp_path):
     source = Dataset(PV51_STUDY_PATH / "10" / "fid")
     dataset_path = tmp_path / "dataset" / "fid"


### PR DESCRIPTION
…_EncSteps1` values

Fixes #66