### PR TITLE
`Dataset._sub_parameters` uses global `str.replace`, corrupting prefi…

### DIFF
--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -254,7 +254,8 @@ class Dataset:
         return self
 
     def _set_state(self, passed):
-        result = deepcopy(DEFAULT_STATES[self.type])
+        result = deepcopy(getattr(self, "_state", DEFAULT_STATES[self.type]))
+        passed = deepcopy(passed)
 
         if "parameter_files" in passed:
             passed["parameter_files"] = result["parameter_files"] + passed["parameter_files"]
@@ -577,16 +578,23 @@ class Dataset:
                 raise PropertyConditionNotMet from KeyError
 
     def _sub_parameters(self, recipe):
-        # entries with property e.g. VisuFGOrderDesc.nested to self._dataset['VisuFGOrderDesc'].nested
-        for match in re.finditer(r"#[a-zA-Z0-9_]+\.[a-zA-Z]+", recipe):
-            m = re.match("#[a-zA-Z0-9_]+", match.group())
-            recipe = recipe.replace(m.group(), f"self['{m.group()[1:]}']")
-        # entries without property e.g. VisuFGOrderDesc to self._dataset['VisuFGOrderDesc'].value
-        for match in re.finditer("@[a-zA-Z0-9_]+", recipe):
-            recipe = recipe.replace(match.group(), f"self.{match.group()[1:]}")
-        for match in re.finditer("#[a-zA-Z0-9_]+", recipe):
-            recipe = recipe.replace(match.group(), f"self['{match.group()[1:]}'].value")
-        return recipe
+        def substitute_parameter(match):
+            name = match.group("name")
+            accessor = match.group("accessor")
+            if accessor is not None:
+                return f"self['{name}'].{accessor}"
+            return f"self['{name}'].value"
+
+        recipe = re.sub(
+            r"#(?P<name>[a-zA-Z0-9_]+)(?:\.(?P<accessor>[a-zA-Z_][a-zA-Z0-9_]*))?(?![a-zA-Z0-9_])",
+            substitute_parameter,
+            recipe,
+        )
+        return re.sub(
+            r"@(?P<name>[a-zA-Z0-9_]+)(?![a-zA-Z0-9_])",
+            lambda match: f"self.{match.group('name')}",
+            recipe,
+        )
 
     """
     SCHEMA
@@ -830,8 +838,24 @@ class Dataset:
             props = list(vars(self).keys())
 
         # list of Dataset properties to be excluded from the export
-        reserved = ["_parameters", "path", "_data", "_traj", "_fid_companions", "_state", "_schema", "random_access", "study_id", "exp_id", "proc_id", "subj_id", "_properties"]
-        props = list(set(props) - set(reserved))
+        reserved = {
+            "_parameters",
+            "path",
+            "_data",
+            "_traj",
+            "_fid_companions",
+            "_state",
+            "_schema",
+            "random_access",
+            "study_id",
+            "exp_id",
+            "proc_id",
+            "subj_id",
+            "_properties",
+            "type",
+            "subtype",
+        }
+        props = [prop for prop in props if prop not in reserved]
 
         properties = {}
 
@@ -871,9 +895,11 @@ class Dataset:
         for q in query:
             try:
                 if not eval(self._sub_parameters(q), {**globals(), "self": self}):
-                    raise FilterEvalFalse
-            except (KeyError, AttributeError) as e:
-                raise FilterEvalFalse from e
+                    raise FilterEvalFalse(f"Query evaluated false: {q!r}")
+            except FilterEvalFalse:
+                raise
+            except (KeyError, AttributeError, NameError, SyntaxError, TypeError) as error:
+                raise FilterEvalFalse(f"Invalid query {q!r}: {type(error).__name__}: {error}") from error
 
     """
     PROPERTIES

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -10,7 +10,7 @@ import pytest
 
 from brukerapi.cli import report as cli_report
 from brukerapi.dataset import LOAD_STAGES, Dataset
-from brukerapi.exceptions import InvalidDataset, TrajNotLoaded, UnknownAcqSchemeException, UnsuportedDatasetType
+from brukerapi.exceptions import FilterEvalFalse, InvalidDataset, TrajNotLoaded, UnknownAcqSchemeException, UnsuportedDatasetType
 
 data = 0
 PV51_STUDY_PATH = Path("test/test_data/PV51/0.2H2")
@@ -353,6 +353,36 @@ def test_epi_standard_kblock_warns_on_nonzero_discarded_samples():
     assert np.array_equal(trimmed[:, 0], np.arange(6))
 
 
+def test_recipe_substitution_preserves_overlapping_identifiers():
+    dataset = Dataset.__new__(Dataset)
+    recipe = "@Foo + @FooBar + #X + #XY + #Matrix.tuple"
+
+    substituted = dataset._sub_parameters(recipe)
+
+    assert substituted == (
+        "self.Foo + self.FooBar + self['X'].value + "
+        "self['XY'].value + self['Matrix'].tuple"
+    )
+
+
+@pytest.mark.parametrize(
+    ("query", "error_type"),
+    [
+        ("unknown_name > 0", NameError),
+        ("self.type ==", SyntaxError),
+        ("self.type + 1", TypeError),
+    ],
+)
+def test_dataset_query_wraps_malformed_expressions(query, error_type):
+    dataset = Dataset.__new__(Dataset)
+    dataset.type = "fid"
+
+    with pytest.raises(FilterEvalFalse, match=rf"Invalid query .*{re.escape(query)}") as error:
+        dataset.query(query)
+
+    assert isinstance(error.value.__cause__, error_type)
+
+
 @pytest.mark.skipif(not PV51_STUDY_PATH.is_dir(), reason="PV51 test data is not available")
 def test_report_default_directory_and_cli_file_outputs(tmp_path):
     source = Dataset(PV51_STUDY_PATH / "10" / "fid")
@@ -360,14 +390,14 @@ def test_report_default_directory_and_cli_file_outputs(tmp_path):
     source.write(dataset_path)
     dataset = Dataset(dataset_path)
 
-    dataset.report(props=["type"])
+    dataset.report(props=["scheme_id"])
     default_report = dataset.path.parent / f"{dataset.id}.json"
-    assert json.loads(default_report.read_text()) == {"type": "fid"}
+    assert json.loads(default_report.read_text()) == {"scheme_id": "CART_3D"}
 
     output_directory = tmp_path / "reports"
     output_directory.mkdir()
-    dataset.report(output_directory, props=["type"])
-    assert json.loads((output_directory / f"{dataset.id}.json").read_text()) == {"type": "fid"}
+    dataset.report(output_directory, props=["scheme_id"])
+    assert json.loads((output_directory / f"{dataset.id}.json").read_text()) == {"scheme_id": "CART_3D"}
 
     cli_output = tmp_path / "cli-report.json"
     cli_report(
@@ -375,11 +405,42 @@ def test_report_default_directory_and_cli_file_outputs(tmp_path):
             input=str(dataset_path),
             output=str(cli_output),
             format="json",
-            props=["type"],
+            props=["scheme_id"],
             verbose=False,
         )
     )
-    assert json.loads(cli_output.read_text()) == {"type": "fid"}
+    assert json.loads(cli_output.read_text()) == {"scheme_id": "CART_3D"}
+
+
+def test_to_dict_excludes_dataset_typing_and_preserves_property_order():
+    dataset = Dataset.__new__(Dataset)
+    dataset.type = "fid"
+    dataset.subtype = ""
+    dataset.first = 1
+    dataset.second = 2
+    dataset.third = 3
+
+    exported = dataset.to_dict()
+
+    assert list(exported) == ["first", "second", "third"]
+    assert exported == {"first": 1, "second": 2, "third": 3}
+
+
+def test_chained_dataset_configuration_merges_onto_current_state(tmp_path):
+    path = tmp_path / "2dseq"
+    path.touch()
+    dataset = Dataset(path, load=LOAD_STAGES["empty"])
+    first_config = {"mmap": True, "parameter_files": ["method"]}
+
+    returned = dataset(**first_config)(scale=False, property_files=[tmp_path / "custom.json"])
+
+    assert returned is dataset
+    assert dataset._state["mmap"] is True
+    assert dataset._state["scale"] is False
+    assert dataset._state["load"] == LOAD_STAGES["empty"]
+    assert dataset._state["parameter_files"][-1] == "method"
+    assert dataset._state["property_files"][-1] == tmp_path / "custom.json"
+    assert first_config == {"mmap": True, "parameter_files": ["method"]}
 
 
 @pytest.mark.skip(reason="in progress")


### PR DESCRIPTION
…xed parameter names

Fixes #77

`Dataset.query()` leaks `NameError`/`SyntaxError` from malformed filter strings Fixes #78

Fixes #79

`Dataset._set_state` rebuilds from defaults on every `__call__`, dropping chained configuration Fixes #81