### PR TITLE
`VisuCoreDiskSliceOrder=disk_reverse_slice_order` raises `InvalidData…

### DIFF
--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -597,8 +597,18 @@ class Schema2dseq(Schema):
             return data
 
         axis = self._frame_group_axis("FG_SLICE")
-        if axis is None:
-            raise InvalidDataset("VisuCoreDiskSliceOrder requests reversed slices, but no FG_SLICE axis is present")
+        if axis is None and getattr(self._dataset, "encoded_dim", None) == 3:
+            # A 3-D VisuCore volume stores slices in its third encoded
+            # dimension; it does not need an FG_SLICE frame group.
+            axis = 2
+        if axis is None or axis >= data.ndim:
+            warnings.warn(
+                "VisuCoreDiskSliceOrder requests reversed slices but no slice axis is identifiable "
+                f"for {getattr(self._dataset, 'path', '<unknown>')}; leaving order unchanged",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return data
         return np.flip(data, axis=axis)
 
     def _complex_frame_axis(self, data):

--- a/brukerapi/splitters.py
+++ b/brukerapi/splitters.py
@@ -197,17 +197,17 @@ class FrameGroupSplitter(Splitter):
         self._split_VisuCoreDataMax(dataset, visu_pars, select, fg_rel_index)
 
         if self.fg == "FG_ECHO":
-            self._split_params_FG_ECHO(dataset, select, fg_abs_index, fg_rel_index, fg_size, visu_pars)
+            self._split_params_FG_ECHO(select, visu_pars)
         if self.fg == "FG_ISA":
-            self._split_params_FG_ISA(dataset, select, fg_abs_index, fg_rel_index, fg_size, visu_pars)
+            self._split_params_FG_ISA(dataset, select, fg_rel_index, visu_pars)
 
         return {"visu_pars": visu_pars}
 
-    def _split_params_FG_ISA(self, dataset, select, fg_abs_index, fg_rel_index, fg_size, visu_pars):
+    def _split_params_FG_ISA(self, dataset, select, fg_rel_index, visu_pars):
         self._split_VisuCoreDataUnits(visu_pars, dataset, select, fg_rel_index)
         self._split_VisuFGElemComment(visu_pars, dataset, select, fg_rel_index)
 
-    def _split_params_FG_ECHO(self, dataset, select, fg_abs_index, fg_rel_index, fg_size, visu_pars):
+    def _split_params_FG_ECHO(self, select, visu_pars):
         self._split_VisuAcqEchoTime(visu_pars, select)
 
     def _split_VisuCoreFrameCount(self, visu_pars, fg_size):
@@ -313,7 +313,14 @@ class SlicePackageSplitter(Splitter):
             dataset_ = Dataset(dataset.path.parents[1] / name, load=0)
 
             # SPLIT parameters
-            dataset_.parameters = self._split_parameters(dataset, frame_range, fg_rel_index, fg_abs_index, sp_index, frame_count)
+            dataset_.parameters = self._split_parameters(
+                dataset,
+                frame_range,
+                fg_rel_index=fg_rel_index,
+                fg_abs_index=fg_abs_index,
+                sp_index=sp_index,
+                frame_count=frame_count,
+            )
 
             # construct properties from the new set of parameters
             dataset_.load_properties()
@@ -335,7 +342,7 @@ class SlicePackageSplitter(Splitter):
 
         return datasets
 
-    def _split_parameters(self, dataset, frame_range, fg_rel_index, fg_abs_index, sp_index, frame_count):
+    def _split_parameters(self, dataset, frame_range, *, fg_rel_index, fg_abs_index, sp_index, frame_count):
         # create a copy of visu_pars of the original data set
         visu_pars_ = copy.deepcopy(dataset.parameters["visu_pars"])
 

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -431,6 +431,49 @@ def test_2dseq_disk_slice_order_is_applied_and_reversible(disk_order, reverse):
     assert np.array_equal(serialized, stored)
 
 
+def test_2dseq_disk_slice_order_uses_third_encoded_axis_for_3d_volume():
+    dataset = SimpleNamespace(
+        _state={"scale": False, "combine_complex": False},
+        encoded_dim=3,
+        dim_type=["spatial", "spatial", "spatial", "<FG_ECHO>"],
+        path="3d-volume/2dseq",
+        _parameter_value=lambda name, default=None: "disk_reverse_slice_order" if name == "VisuCoreDiskSliceOrder" else default,
+    )
+    schema = Schema2dseq.__new__(Schema2dseq)
+    schema._dataset = dataset
+    layouts = {
+        "shape_storage": (2, 3, 4, 2),
+        "shape_final": (2, 3, 4, 2),
+        "shape_fg": (2,),
+    }
+    stored = np.arange(48).reshape(layouts["shape_storage"], order="F")
+
+    decoded = schema.deserialize(stored, layouts)
+    serialized = schema.serialize(decoded, layouts)
+
+    assert np.array_equal(decoded, np.flip(stored, axis=2))
+    assert np.array_equal(serialized, stored)
+
+
+def test_2dseq_disk_slice_order_without_slice_axis_warns_and_leaves_data_unchanged():
+    dataset = SimpleNamespace(
+        _state={"scale": False, "combine_complex": False},
+        encoded_dim=2,
+        dim_type=["spatial", "spatial", "<FG_ECHO>"],
+        path="no-slice-axis/2dseq",
+        _parameter_value=lambda name, default=None: "disk_reverse_slice_order" if name == "VisuCoreDiskSliceOrder" else default,
+    )
+    schema = Schema2dseq.__new__(Schema2dseq)
+    schema._dataset = dataset
+    stored = np.arange(12).reshape((2, 3, 2), order="F")
+    layouts = {"shape_storage": stored.shape, "shape_final": stored.shape, "shape_fg": (2,)}
+
+    with pytest.warns(RuntimeWarning, match="no slice axis is identifiable"):
+        decoded = schema.deserialize(stored, layouts)
+
+    assert np.array_equal(decoded, stored)
+
+
 @pytest.mark.parametrize(
     ("aq_mod", "encoding_space", "expected"),
     [


### PR DESCRIPTION
…set` on every `VisuCoreDim=3` volume (regression from #98)

Fixes #129