### PR TITLE
reordering fix `ACQ_obj_order` never applied: `fid` slice axis delive…

### DIFF
--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -190,7 +190,26 @@ class SchemaFid(Schema):
         if "EPI" in self._dataset.scheme_id:
             data = self._mirror_odd_lines(data)
 
+        data = self._reorder_objects(data, dir="FW")
+
         return data
+
+    def _reorder_objects(self, data, dir="FW"):
+        """Map the stored acquisition-object order onto the labelled slice axis."""
+        if "slice" not in self._dataset.dim_type:
+            return data
+
+        try:
+            object_order = np.atleast_1d(self._dataset["ACQ_obj_order"].value).astype(int)
+        except KeyError:
+            return data
+
+        axis = self._dataset.dim_type.index("slice")
+        if object_order.size != data.shape[axis] or np.array_equal(object_order, np.arange(object_order.size)):
+            return data
+
+        indices = np.argsort(object_order) if dir == "FW" else object_order
+        return np.take(data, indices, axis=axis)
 
     def _acquisition_trim(self, data, layouts):
         acquisition_offset = layouts["acquisition_position"][0]
@@ -281,6 +300,8 @@ class SchemaFid(Schema):
         return data
 
     def serialize(self, data, layouts):
+        data = self._reorder_objects(data, dir="BW")
+
         if "EPI" in self._dataset.scheme_id:
             data = self._mirror_odd_lines(data)
 

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -890,6 +890,26 @@ def test_schema_warns_when_dim_type_does_not_describe_layout_rank():
         SchemaRawdata(dataset)
 
 
+def test_fid_object_order_reorders_slice_axis_and_is_reversible():
+    class ObjectOrderDataset:
+        dim_type = ["k_space_encode_step_0", "slice"]
+
+        def __init__(self):
+            self.parameters = {"ACQ_obj_order": SimpleNamespace(value=np.array([0, 2, 4, 1, 3]))}
+
+        def __getitem__(self, key):
+            return self.parameters[key]
+
+    schema = SchemaFid.__new__(SchemaFid)
+    schema._dataset = ObjectOrderDataset()
+    stored = np.arange(5).reshape((1, 5))
+
+    ordered = schema._reorder_objects(stored, dir="FW")
+
+    assert np.array_equal(ordered, np.array([[0, 3, 1, 4, 2]]))
+    assert np.array_equal(schema._reorder_objects(ordered, dir="BW"), stored)
+
+
 @pytest.mark.skip(reason="in progress")
 def test_parameters(test_parameters):
     dataset = Dataset(test_parameters[0], load=False)


### PR DESCRIPTION
…red in acquisition order (silent slice permutation)

Fixes #130