### PR TITLE
Read datasets through the pathlib protocol so archives work

### DIFF
--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -26,6 +26,7 @@ from .exceptions import (
     UnsupportedDatasetType,
 )
 from .jcampdx import JCAMPDX
+from .paths import as_path, file_size, listdir, read_array, traverse, with_suffix
 from .schemas import Schema2dseq, SchemaFid, SchemaFidCompanion, SchemaRawdata, SchemaTraj
 
 LOAD_STAGES = {
@@ -196,14 +197,14 @@ class Dataset:
         :raise: :IncompleteDataset: If any of the JCAMP-DX files, necessary to create a Dataset instance is missing
 
         """
-        self.path = Path(path)
+        self.path = as_path(path)
 
         if not self.path.exists() and state.get("load") is not LOAD_STAGES["empty"]:
             raise FileNotFoundError(self.path)
 
         # directory constructor
         if self.path.is_dir():
-            content = os.listdir(self.path)
+            content = listdir(self.path)
             rawdata_jobs = sorted(
                 (name for name in content if re.fullmatch(r"rawdata\.job\d+", name)),
                 key=lambda name: int(name.rsplit("job", 1)[1]),
@@ -230,7 +231,7 @@ class Dataset:
         if self.type == "fid" and self.subtype in FID_COMPANION_SUBTYPES and not state.get("_auxiliary"):
             raise UnsupportedDatasetType(
                 f"{self.path.name} is a fid companion (spec §3.5); load it as "
-                f"Dataset({self.path.with_suffix('')!s}).fid_companions[{self.subtype!r}]"
+                f"Dataset({with_suffix(self.path, '')!s}).fid_companions[{self.subtype!r}]"
             )
         if not self._is_supported_subtype() and not (state.get("_auxiliary") and self.type == "fid" and self.subtype in FID_COMPANION_SUBTYPES):
             raise UnsupportedDatasetType(self.path.name)
@@ -250,7 +251,7 @@ class Dataset:
     @staticmethod
     def is_supported_path(path, dataset_types=None):
         """Return whether a filename denotes a supported primary dataset binary."""
-        path = Path(path)
+        path = as_path(path)
         dataset_type = path.stem
         subtype = path.suffix.removeprefix(".")
         if dataset_type not in SUPPORTED_SUBTYPES:
@@ -322,13 +323,13 @@ class Dataset:
         # Check whether all necessary JCAMP-DX files are present
         if self._state.get("load") >= LOAD_STAGES["parameters"]:
             for i in DEFAULT_STATES[self.type]["parameter_files"]:
-                param_path = self.path.parent / RELATIVE_PATHS[self.type][i]
-                if i not in set(os.listdir(str(param_path.parent))):
+                param_path = traverse(self.path.parent, RELATIVE_PATHS[self.type][i])
+                if i not in set(listdir(param_path.parent)):
                     raise IncompleteDataset(f"missing required parameter file: {i} ({param_path})")
 
             if self.type == "2dseq":
-                visu_path = self.path.parent / RELATIVE_PATHS[self.type]["visu_pars"]
-                empty_components = [path for path in (self.path, visu_path) if path.is_file() and path.stat().st_size == 0]
+                visu_path = traverse(self.path.parent, RELATIVE_PATHS[self.type]["visu_pars"])
+                empty_components = [path for path in (self.path, visu_path) if path.is_file() and file_size(path) == 0]
                 if empty_components:
                     components = ", ".join(f"{path.name} ({path})" for path in empty_components)
                     raise InvalidDataset(f"Invalid dataset, empty or incomplete reconstruction: empty {components}")
@@ -409,7 +410,7 @@ class Dataset:
             dataset["PVM_DwDir"].value
 
         """
-        path = self.path.parent / RELATIVE_PATHS[self.type][file]
+        path = traverse(self.path.parent, RELATIVE_PATHS[self.type][file])
 
         if not hasattr(self, "_parameters") or self._parameters is None:
             self._parameters = {path.name: JCAMPDX(path)}
@@ -711,10 +712,10 @@ class Dataset:
         1D ndarray containing the full data vector
         """
 
-        actual_bytes = os.stat(path).st_size
+        actual_bytes = file_size(path)
         expected_bytes = int(np.prod(shape) * dtype.itemsize)
         if actual_bytes != expected_bytes:
-            with Path(path).open("rb") as binary:
+            with path.open("rb") as binary:
                 signature = binary.read(42)
 
             if signature == b"version https://git-lfs.github.com/spec/v1":
@@ -735,7 +736,7 @@ class Dataset:
                 f"Invalid dataset size at {path}: expected {expected_bytes} bytes for shape {tuple(shape)} and dtype {dtype}, got {actual_bytes} bytes"
             )
 
-        return np.array(np.memmap(path, dtype=dtype, shape=shape, order="F")[:])
+        return read_array(path, dtype, shape)
 
     def _write_data(self, path):
         data = self._data.copy()
@@ -751,7 +752,7 @@ class Dataset:
     """
 
     def load_traj(self, **kwargs):
-        if Path(self.path.parent / "traj").exists() and self.type != "traj":
+        if (self.path.parent / "traj").exists() and self.type != "traj":
             self._traj = Dataset(
                 self.path.parent / "traj",
                 load=LOAD_STAGES["empty"],
@@ -777,7 +778,7 @@ class Dataset:
             return
 
         for subtype in sorted(FID_COMPANION_SUBTYPES):
-            path = self.path.with_suffix(f".{subtype}")
+            path = with_suffix(self.path, f".{subtype}")
             if not path.exists():
                 continue
 
@@ -788,7 +789,7 @@ class Dataset:
                 companion.shape_storage = self.shape_storage
                 companion.dim_type = self.dim_type
             else:
-                companion.shape_storage = (path.stat().st_size // self.numpy_dtype.itemsize,)
+                companion.shape_storage = (file_size(path) // self.numpy_dtype.itemsize,)
                 companion.dim_type = ["sample"]
             companion._schema = SchemaFidCompanion(companion, primary_schema=self._schema)
             companion.load_data()

--- a/brukerapi/folders.py
+++ b/brukerapi/folders.py
@@ -18,6 +18,7 @@ from .exceptions import (
     UnsupportedDatasetType,
 )
 from .jcampdx import JCAMPDX
+from .paths import as_path
 
 DEFAULT_DATASET_STATE = {"parameter_files": [], "property_files": [], "load": 3}
 
@@ -48,7 +49,7 @@ class Folder:
         if dataset_index is None:
             dataset_index = ["fid", "2dseq", "rawdata"]
 
-        self.path = Path(path)
+        self.path = as_path(path)
 
         self.validate()
 
@@ -244,7 +245,7 @@ class Folder:
     @staticmethod
     def contains(path: str | Path, required: list) -> bool:
         """Checks whether folder specified by path contains all required files."""
-        path = Path(path)
+        path = as_path(path)
         required_set = set(required)
         existing_files = {f.name for f in path.iterdir()}
         return required_set.issubset(existing_files)
@@ -334,7 +335,7 @@ class Study(Folder):
         if dataset_index is None:
             dataset_index = ["fid", "2dseq", "rawdata"]
 
-        self.path = Path(path)
+        self.path = as_path(path)
         self.validate()
         super().__init__(path, parent=parent, recursive=recursive, dataset_index=dataset_index, dataset_state=dataset_state)
 
@@ -404,7 +405,7 @@ class Experiment(Folder):
         if dataset_index is None:
             dataset_index = ["fid", "rawdata"]
 
-        self.path = Path(path)
+        self.path = as_path(path)
         self.validate()
         super().__init__(path, parent=parent, recursive=recursive, dataset_index=dataset_index, dataset_state=dataset_state)
 
@@ -447,7 +448,7 @@ class Processing(Folder):
         if dataset_index is None:
             dataset_index = ["2dseq"]
 
-        self.path = Path(path)
+        self.path = as_path(path)
         self.validate()
         super().__init__(path, parent=parent, recursive=recursive, dataset_index=dataset_index, dataset_state=dataset_state)
 

--- a/brukerapi/jcampdx.py
+++ b/brukerapi/jcampdx.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 
 from .exceptions import InvalidJcampdxFile, JcampdxFileError, JcampdxVersionError, ParameterNotFound
+from .paths import as_path
 
 SUPPORTED_VERSIONS = ["4.24", "5.0", "5.00 Bruker JCAMP library", "5.00 BRUKER JCAMP library", "5.01"]
 GRAMMAR = {
@@ -603,7 +604,7 @@ class JCAMPDX:
             load = True
 
         # If path is directory
-        self.path = Path(path)
+        self.path = as_path(path)
         self._version = None
 
         if self.path.is_dir():
@@ -729,8 +730,15 @@ class JCAMPDX:
     def set_parameter(self, key, value):
         self.params[key] = value
 
-    def get_value(self, key):
-        return self.params[key].value
+    def get_value(self, key, default=None):
+        """Value of parameter `key`, or `default` when it is absent.
+
+        Which parameters a file carries is ParaVision-version dependent, so a
+        caller that tolerates an absent key would otherwise have to wrap every
+        read in ``try``/``except KeyError``.
+        """
+        parameter = self.params.get(key)
+        return default if parameter is None else parameter.value
 
     def get_list(self, key):
         """Idea is to ensure, that a parameter will be a list even if parameter only contains one entry"""
@@ -849,7 +857,7 @@ class JCAMPDX:
 
     @classmethod
     def read_jcampdx(cls, path):
-        path = Path(path)
+        path = as_path(path)
 
         params = {}
 

--- a/brukerapi/paths.py
+++ b/brukerapi/paths.py
@@ -1,0 +1,79 @@
+"""Path handling that does not assume an operating-system filesystem.
+
+Every path a :class:`~brukerapi.dataset.Dataset` or :class:`~brukerapi.folders.Folder`
+is built from passes through this module, so any object implementing the pathlib
+read protocol can stand in for a real path. In particular a
+:class:`zipfile.Path` works, which lets a dataset be read straight out of a
+``.zip``/``.PvDatasets`` archive without extracting it first.
+
+The protocol used here is deliberately small: ``iterdir``, ``open``, ``exists``,
+``is_dir``, ``is_file``, ``parent``, ``name``, ``stem``, ``suffix`` and ``/``.
+Everything else an archive member cannot do -- ``stat``, ``with_suffix``,
+``os.listdir``, ``np.memmap`` -- has a helper here that falls back to something
+it can.
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+
+
+def as_path(path):
+    """Return `path` as a :class:`pathlib.Path`, passing path-likes through.
+
+    ``str`` and :class:`os.PathLike` are coerced as before; anything else is
+    assumed to implement the read protocol above and is returned unchanged
+    (``Path(zipfile.Path(...))`` raises).
+    """
+    if isinstance(path, (str, os.PathLike)):
+        return Path(path)
+    return path
+
+
+def traverse(base, relative):
+    """Resolve a ``'../../method'``-style relative path against `base`.
+
+    :class:`zipfile.Path` joins textually and never collapses ``..``, so the
+    walk is done one segment at a time through ``parent`` rather than by
+    joining a string.
+    """
+    for part in str(relative).replace(os.sep, "/").split("/"):
+        if part in ("", "."):
+            continue
+        base = base.parent if part == ".." else base / part
+    return base
+
+
+def with_suffix(path, suffix):
+    """`path` with its final suffix replaced -- ``Path.with_suffix`` for any path-like."""
+    return path.parent / f"{path.stem}{suffix}"
+
+
+def listdir(path):
+    """Names of the entries in the directory `path` -- ``os.listdir`` for any path-like."""
+    return [entry.name for entry in path.iterdir()]
+
+
+def file_size(path):
+    """Size in bytes of the file `path` points at."""
+    stat = getattr(path, "stat", None)
+    if stat is not None:
+        return stat().st_size
+    with path.open("rb") as binary:
+        binary.seek(0, os.SEEK_END)
+        return binary.tell()
+
+
+def read_array(path, dtype, shape, order="F"):
+    """Read the binary file `path` into an array of `shape`.
+
+    A filesystem path is memory-mapped as before. An archive member cannot be
+    (a memory map cannot address a compressed member), so it degrades to a full
+    read.
+    """
+    if isinstance(path, (str, os.PathLike)):
+        return np.array(np.memmap(path, dtype=dtype, shape=shape, order=order)[:])
+    with path.open("rb") as binary:
+        buffer = binary.read()
+    return np.frombuffer(buffer, dtype=dtype).reshape(shape, order=order)

--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import numpy as np
 
 from .exceptions import ConditionNotMet, InvalidDataset, MissingProperty, UnknownAcqSchemeException
+from .paths import read_array
 
 config_paths = {"core": Path(__file__).parents[0] / "config", "custom": Path(__file__).parents[0] / "config"}
 
@@ -423,7 +424,7 @@ class SchemaFid(Schema):
         random access
         """
         array_ra = np.zeros(layouts_ra["storage"], dtype=self._dataset.numpy_dtype)
-        fp = np.memmap(self._dataset.path, dtype=self._dataset.numpy_dtype, mode="r", shape=layouts["storage"], order="F")
+        fp = read_array(self._dataset.path, self._dataset.numpy_dtype, layouts["storage"])
 
         for index_ra in np.ndindex(layouts_ra["k_space"][1:]):
             # index of line in the original k_space
@@ -1065,7 +1066,7 @@ class Schema2dseq(Schema):
 
         array_ra = np.zeros(layouts_ra["shape_storage"], dtype=self._dataset.numpy_dtype)
 
-        fp = np.memmap(self._dataset.path, dtype=self._dataset.numpy_dtype, mode="r", shape=layouts["shape_storage"], order="F")
+        fp = read_array(self._dataset.path, self._dataset.numpy_dtype, layouts["shape_storage"])
 
         for slice_ra, slice_full in self._generate_ra_indices(layouts_ra, layouts):
             array_ra[slice_ra] = np.array(fp[slice_full])

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -1,0 +1,121 @@
+"""Datasets read through the pathlib read protocol, not the filesystem.
+
+A ``zipfile.Path`` stands in for a real path, so a dataset inside a
+``.zip``/``.PvDatasets`` archive is readable without extracting it. The dataset
+below is synthesised, so these tests need no test-data corpus.
+"""
+
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from brukerapi.dataset import Dataset
+from brukerapi.folders import Experiment, Folder
+from brukerapi.jcampdx import JCAMPDX
+from brukerapi.paths import as_path, file_size, listdir, traverse, with_suffix
+
+VISU_PARS = """##TITLE=Parameter List, ParaVision 6.0.1
+##JCAMPDX=4.24
+##$VisuCreatorVersion=<6.0.1>
+##$VisuCoreDim=2
+##$VisuCoreSize=( 2 )
+4 3
+##$VisuCoreDimDesc=( 2 )
+spatial spatial
+##$VisuCoreExtent=( 2 )
+20 15
+##$VisuCoreFrameCount=2
+##$VisuCoreWordType=_16BIT_SGN_INT
+##$VisuCoreByteOrder=littleEndian
+##$VisuCoreDataSlope=( 2 )
+1 1
+##$VisuCoreDataOffs=( 2 )
+0 0
+##$VisuCoreOrientation=( 2, 9 )
+1 0 0 0 1 0 0 0 1 1 0 0 0 1 0 0 0 1
+##$VisuCorePosition=( 2, 3 )
+0 0 0 0 0 1
+##$VisuFGOrderDescDim=1
+##$VisuFGOrderDesc=( 1 )
+(2, <FG_SLICE>, <>, 0, 0)
+##END=
+"""
+
+ACQP = "##TITLE=Parameter List\n##JCAMPDX=4.24\n##$ACQ_scan_name=( 64 )\n<demo>\n##END=\n"
+
+DATA = np.arange(24, dtype="<i2").reshape((4, 3, 2), order="F")
+
+
+@pytest.fixture
+def study_dir(tmp_path):
+    """A one-experiment, one-processing study on the filesystem."""
+    proc = tmp_path / "study" / "1" / "pdata" / "1"
+    proc.mkdir(parents=True)
+    (tmp_path / "study" / "1" / "acqp").write_text(ACQP)
+    (proc / "visu_pars").write_text(VISU_PARS)
+    (proc / "2dseq").write_bytes(DATA.tobytes(order="F"))
+    return tmp_path / "study"
+
+
+@pytest.fixture
+def study_zip(study_dir, tmp_path):
+    """The same study inside an archive, as a :class:`zipfile.Path` root."""
+    archive = tmp_path / "study.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        for path in sorted(study_dir.rglob("*")):
+            if path.is_file():
+                zf.write(path, str(path.relative_to(study_dir.parent)))
+    return next(child for child in zipfile.Path(zipfile.ZipFile(archive)).iterdir() if child.is_dir())
+
+
+def test_dataset_reads_from_archive_identically(study_dir, study_zip):
+    """The array and the axis labels do not depend on where the data was read from."""
+    from_dir = Dataset(study_dir / "1" / "pdata" / "1" / "2dseq", scale=False)
+    from_zip = Dataset(study_zip / "1" / "pdata" / "1" / "2dseq", scale=False)
+
+    assert np.array_equal(from_zip.data, DATA)
+    assert np.array_equal(from_zip.data, from_dir.data)
+    assert list(from_zip.dim_type) == list(from_dir.dim_type)
+    assert from_zip.shape_final == from_dir.shape_final
+
+
+def test_parameters_resolve_through_relative_paths(study_dir, study_zip):
+    """``../../acqp`` resolves inside an archive, where ``..`` is not collapsed."""
+    dataset = Dataset(study_zip / "1" / "pdata" / "1" / "2dseq", scale=False,
+                      parameter_files=["acqp"])
+    assert dataset["ACQ_scan_name"].value == "<demo>"
+
+
+def test_folder_traverses_an_archive(study_zip):
+    folder = Folder(study_zip)
+    assert [child.path.name for child in folder.children if isinstance(child, Experiment)] == ["1"]
+
+
+def test_jcampdx_reads_from_archive(study_zip):
+    visu_pars = JCAMPDX(study_zip / "1" / "pdata" / "1" / "visu_pars")
+    assert visu_pars.get_value("VisuCoreDim") == 2
+
+
+def test_get_value_default_for_absent_key(study_dir):
+    """Which parameters exist is ParaVision-version dependent, so absence needs a default."""
+    visu_pars = JCAMPDX(study_dir / "1" / "pdata" / "1" / "visu_pars")
+    assert visu_pars.get_value("VisuCoreDim", 99) == 2
+    assert visu_pars.get_value("NoSuchParameter") is None
+    assert visu_pars.get_value("NoSuchParameter", "fallback") == "fallback"
+    with pytest.raises(KeyError):
+        visu_pars["NoSuchParameter"]
+
+
+def test_path_helpers_work_for_both_kinds(study_dir, study_zip):
+    assert isinstance(as_path(str(study_dir)), Path)
+    assert as_path(study_zip) is study_zip                        # passed through, not coerced
+
+    for root in (study_dir, study_zip):
+        proc = root / "1" / "pdata" / "1"
+        assert sorted(listdir(proc)) == ["2dseq", "visu_pars"]
+        assert file_size(proc / "2dseq") == DATA.nbytes
+        assert traverse(proc, "../../acqp").name == "acqp"
+        assert traverse(proc, "../../acqp").exists()
+        assert with_suffix(proc / "2dseq", ".job0").name == "2dseq.job0"


### PR DESCRIPTION
Every entry point coerces its argument with `Path()` and then reaches for
filesystem-only calls — `os.listdir`, `os.stat`, `Path.with_suffix`,
`np.memmap` — so a dataset can only be read from a real directory. A caller
holding a `.zip`/`.PvDatasets` archive has to extract it first, which costs disk
and time even for a metadata-only read.

This routes every read through a new `brukerapi.paths`, whose helpers fall back
to what an archive member can do:

| Was | Now |
|---|---|
| `os.listdir(path)` | `listdir(path)` → `iterdir` |
| `path.stat().st_size` | `file_size(path)` → seek-to-end when there is no `stat` |
| `path.with_suffix(s)` | `with_suffix(path, s)` → `parent / f"{stem}{s}"` |
| `np.memmap(...)` | `read_array(...)` → full read when the path cannot be mapped |
| `Path(path)` | `as_path(path)` → leaves a non-PathLike object alone |

Two of those need a word. `traverse()` resolves `'../../method'`-style relative
paths one segment at a time through `parent`, because `zipfile.Path` joins
textually and never collapses `..`. And `as_path()` has to exist at all because
`Path(zipfile.Path(...))` raises — coercion is what locks the readers to the
filesystem.

Callers can now pass `zipfile.Path(ZipFile(archive))` anywhere a path is taken:

```python
root = next(c for c in zipfile.Path(ZipFile("study.PvDatasets")).iterdir() if c.is_dir())
dataset = Dataset(root / "1" / "pdata" / "1" / "2dseq")
Study(root).get_experiment_list()
```

No new dependency. Write paths are deliberately unchanged — an archive member
cannot be written in place. Random access degrades to a full read for an
archive-backed dataset, since a memory map cannot address a compressed member.

`JCAMPDX.get_value` gains a `default`. Which parameters a file carries is
ParaVision-version dependent, so a caller that tolerates an absent key currently
wraps every read in `try`/`except KeyError`.

### Testing

`test/test_paths.py` adds 6 tests over a synthesised one-experiment study, so
they need no test-data corpus: the array and `dim_type` read out of a zip match
the same study on disk, `../../acqp` resolves inside the archive, `Folder`
traverses it, and each path helper is checked against both a real path and a
`zipfile.Path`.

Locally the suite goes 145 → 151 passed with the same 2 failures already present
on master (`test_fid_quadrature_mode_controls_real_imag_deinterleave`, which
builds its dataset from a `SimpleNamespace` lacking `dim_type` — unrelated to
this change).

I've also been running it downstream: reading ~1,570 reconstructions across
PV5.1, PV6.0.1, PV7.0.0 and PV360, from directories and from both archive
formats, produces byte-identical arrays either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019P9Qp72Xymjic1eT9sMB5Q
