### PR TITLE
Read a parameter written with no value as an empty string

### DIFF
--- a/brukerapi/jcampdx.py
+++ b/brukerapi/jcampdx.py
@@ -389,6 +389,9 @@ class GenericParameter(Parameter):
                 pass
 
             return np.array(val_strs)
+        if not val_strs:
+            # a parameter written with no value at all, e.g. `##$ACQ_operator= `
+            return ""
         return val_strs[0]
 
     @staticmethod

--- a/test/test_jcampdx.py
+++ b/test/test_jcampdx.py
@@ -61,6 +61,16 @@ def test_parse_value_preserves_delimiters_inside_angle_brackets():
     assert GenericParameter.parse_value(struct) == [7, "<label, with comma) and parenthesis>", 9]
 
 
+def test_parse_value_of_an_empty_parameter():
+    """A parameter can be written with no value at all: `##$ACQ_operator= `.
+
+    Real ParaVision exports do this for unset text fields. Reading one raised
+    IndexError, which took down every consumer of the whole file.
+    """
+    assert GenericParameter.parse_value("") == ""
+    assert GenericParameter.parse_value(" ") == ""
+
+
 def test_parallel_lists_preserve_delimiters_inside_angle_brackets():
     value = "(first, <Display, One>) (second, <Display) Two, value>)"
 


### PR DESCRIPTION
ParaVision writes an unset text field with no value at all. From a real PV6.0.1
`acqp`:

```
##$ACQ_operator= 
##$ACQ_RF_power=0
```

`parse_value` filters empty tokens out of the split, which for a whitespace-only
value leaves nothing, and then indexes it:

```python
val_strs = [value for value in cls._split_outside_angle_brackets(val_str, " ") if value]

if len(val_strs) > 1:
    ...
return val_strs[0]          # IndexError when the parameter is empty
```

Parsing is lazy, so the damage is narrower than it first looks and sharper than
it sounds:

```python
>>> j = JCAMPDX("acqp")
>>> len(j.keys())
285
>>> j.get_value("ACQ_scan_name")        # other parameters are fine
'<1_Localizer_GOP (E3)>'
>>> j.get_value("ACQ_operator")
IndexError: list index out of range
>>> j.to_dict()                          # walks every parameter
IndexError: list index out of range
```

So the file loads and its other 284 parameters read, but that one key is
unreadable and the file cannot be serialised at all. `IndexError` is also not
the `KeyError` a caller guards for when a parameter may be absent, so it slips
straight through the handling written for exactly this situation — downstream it
surfaced as a conversion failure blamed on a parameter nothing was using.

This returns the empty string instead: the parameter exists and holds nothing,
which is different from it being absent.

`test/test_jcampdx.py` covers `parse_value("")` and `parse_value(" ")`. The
suite goes 145 → 146 passed with the two pre-existing
`test_fid_quadrature_mode_controls_real_imag_deinterleave` failures unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019P9Qp72Xymjic1eT9sMB5Q
