### PR TITLE
Read the qform ParaVision actually writes, and run the NIfTI oracle in CI (#182)

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -78,7 +78,10 @@ jobs:
       uses: actions/cache@v5
       with:
         path: test/test_data/PV360_StdData
-        key: pv360-stddata-6f1b67e5dbc3d7b3646a6315959ccf6d4bd02237
+        # The suffix tracks which LFS media conftest smudges. Bumping it when
+        # that set grows rebuilds the cache once, instead of re-downloading the
+        # newly required files on every run, because a cache hit is not re-saved.
+        key: pv360-stddata-6f1b67e5dbc3d7b3646a6315959ccf6d4bd02237-nifti
 
     - name: Run all dataset tests
       run: |

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -98,7 +98,10 @@ def _resolve_requested_datasets(opt: str | None):
 
 
 def _is_required_github_data_file(path: Path):
-    return path.name in {"2dseq", "traj"} or path.name.startswith("rawdata.job")
+    # The NIfTI exports are the independent geometry oracle of test_geometry.py.
+    # Leaving them as LFS pointers made that check skip itself in CI, so it was
+    # green whatever it would have found.
+    return path.name in {"2dseq", "traj"} or path.name.startswith("rawdata.job") or path.suffix == ".nii"
 
 
 def _is_git_lfs_pointer(path: Path):

--- a/test/test_geometry.py
+++ b/test/test_geometry.py
@@ -17,10 +17,20 @@ from test.synthetic import axial_orientation, stacked_positions, write_2dseq
 
 SAGITTAL_ORIENTATION = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0])
 PV360_NIFTI_ROOT = Path("test/test_data/PV360_StdData")
+# Every reconstruction that ships a NIfTI export, rather than a fixed list, so
+# a dataset added to the corpus is checked without editing this file.
+PV360_NIFTI_EXPORTS = sorted(
+    directory.parent.relative_to(PV360_NIFTI_ROOT).as_posix() for directory in PV360_NIFTI_ROOT.glob("*/pdata/*/nifti") if any(directory.glob("*.nii"))
+)
 
 
-def nifti_sform(path):
-    """Read the NIfTI-1 sform without making nibabel a test dependency."""
+def nifti_affine(path):
+    """Read the NIfTI-1 image affine without making nibabel a test dependency.
+
+    The standard stores it two independent ways, and a file need only carry one.
+    ParaVision writes the quaternion (`qform_code > 0`) and leaves the sform
+    zeroed, so a reader that consults the sform alone finds nothing at all.
+    """
     header = path.read_bytes()[:348]
     if header.startswith(b"version https://git-lfs.github.com/spec/"):
         pytest.skip("ParaVision NIfTI exports are Git LFS pointers; fetch the LFS assets to validate their affines")
@@ -34,10 +44,37 @@ def nifti_sform(path):
     else:
         pytest.fail(f"{path} is not a NIfTI-1 image")
 
-    sform_code = struct.unpack_from(f"{byte_order}h", header, 254)[0]
-    assert sform_code > 0, f"{path} has no sform"
-    sform = np.asarray(struct.unpack_from(f"{byte_order}12f", header, 280)).reshape(3, 4)
-    return np.vstack((sform, (0.0, 0.0, 0.0, 1.0)))
+    qform_code, sform_code = struct.unpack_from(f"{byte_order}2h", header, 252)
+    if sform_code > 0:
+        sform = np.asarray(struct.unpack_from(f"{byte_order}12f", header, 280)).reshape(3, 4)
+        return np.vstack((sform, (0.0, 0.0, 0.0, 1.0)))
+    if qform_code > 0:
+        return nifti_qform_affine(header, byte_order)
+    pytest.fail(f"{path} declares neither an sform nor a qform")
+
+
+def nifti_qform_affine(header, byte_order):
+    """NIfTI-1 "method 2": the affine as a rotation quaternion and a scaling.
+
+    Only the vector part of the unit quaternion is stored; `pixdim[0]` is the
+    handedness factor applied to the third column.
+    """
+    pixdim = struct.unpack_from(f"{byte_order}8f", header, 76)
+    handedness = pixdim[0] if pixdim[0] else 1.0
+    b, c, d, *origin = struct.unpack_from(f"{byte_order}6f", header, 256)
+    a = np.sqrt(max(0.0, 1.0 - (b * b + c * c + d * d)))
+    rotation = np.array(
+        [
+            [a * a + b * b - c * c - d * d, 2 * (b * c - a * d), 2 * (b * d + a * c)],
+            [2 * (b * c + a * d), a * a + c * c - b * b - d * d, 2 * (c * d - a * b)],
+            [2 * (b * d - a * c), 2 * (c * d + a * b), a * a + d * d - b * b - c * c],
+        ]
+    )
+
+    affine = np.eye(4)
+    affine[:3, :3] = rotation @ np.diag((pixdim[1], pixdim[2], handedness * pixdim[3]))
+    affine[:3, 3] = origin
+    return affine
 
 
 def load(tmp_path, **kwargs):
@@ -135,29 +172,24 @@ def test_report_carries_the_affine_and_omits_it_for_spectroscopy(tmp_path):
     assert "affine" not in spectroscopy.to_dict()
 
 
-@pytest.mark.parametrize(
-    "relative_path",
-    [
-        "T1_FLASH/pdata/1",
-        "T1_FLASH_3D_iso/pdata/1",
-        "T1_RARE/pdata/1",
-        "T2_TurboRARE/pdata/1",
-        "UTE3D/pdata/1",
-    ],
-)
-def test_affine_agrees_with_the_paravision_nifti_sform(relative_path):
+@pytest.mark.parametrize("relative_path", PV360_NIFTI_EXPORTS)
+def test_affine_agrees_with_the_paravision_nifti_export(relative_path):
     """PV's NIfTI export is an independent geometry oracle.
 
-    VisuCore geometry is in the DICOM patient frame, whereas NIfTI sforms are
+    VisuCore geometry is in the DICOM patient frame, whereas a NIfTI affine is
     in RAS.  Therefore the equivalent NIfTI affine negates the patient x/y
     axes (spec 12).
+
+    Every volume of an export shares one geometry -- a diffusion series writes
+    one file per direction -- so all of them are checked, which also pins the
+    export as internally consistent.
     """
     reconstruction = PV360_NIFTI_ROOT / relative_path
-    nifti_path = next((reconstruction / "nifti").glob("*.nii"))
     dataset = Dataset(reconstruction / "2dseq", load=LOAD_STAGES["properties"])
 
-    expected_sform = np.diag((-1.0, -1.0, 1.0, 1.0)) @ dataset.affine
-    assert np.allclose(nifti_sform(nifti_path), expected_sform, atol=1e-5)
+    expected = np.diag((-1.0, -1.0, 1.0, 1.0)) @ dataset.affine
+    for nifti_path in sorted((reconstruction / "nifti").glob("*.nii")):
+        assert np.allclose(nifti_affine(nifti_path), expected, atol=1e-5), nifti_path.name
 
 
 def test_slice_spacing_is_centre_to_centre_not_thickness_plus_distance(tmp_path):


### PR DESCRIPTION
Fixes #182.

`test_affine_agrees_with_the_paravision_nifti_sform` tripped its own `assert sform_code > 0` before it ever compared a matrix, and skipped entirely in CI — so it reported nothing either way.

### Read the form the writer populates

NIfTI-1 stores the affine two independent ways and a file need only carry one. All 14 `PV360_StdData` exports write the quaternion (`qform_code=1`) and leave the sform zeroed — method 2, squarely within the standard — while the helper read offset 280 regardless.

Decoding the qform instead, **the export agrees with the VisuCore-derived affine to 4.8e-07 everywhere**: obliques, the negative-determinant `UTE3D` volume and the diffusion series included. The oracle was sound the whole time and silently confirming the geometry.

`nifti_affine` now takes the sform when there is one, the qform otherwise, and fails only if a file declares neither — so it keeps working if a future ParaVision writes both.

### Cover what is on disk

Coverage follows the `nifti/` directories that exist rather than a hardcoded five, which brings in the four diffusion reconstructions plus `T2map_MSME`, `T2star_FID_EPI` and `T2star_map_MGE`: **14 reconstructions, 166 volumes**. Every volume of an export is checked instead of whichever one `glob` happened to yield first, which also pins each export as internally consistent (they are — spread 0.0 within every directory).

Where no corpus is present the parameter set is empty and the test skips cleanly, rather than erroring on `next()` of an empty glob as it did before.

### Make it run in CI

`conftest` smudged only `2dseq`, `traj` and `rawdata.job*`, so the `.nii` files stayed LFS pointers and `nifti_affine` took its skip branch. `.nii` is now required media — 54 MB of a 1.7 GB dataset.

The cache key gains a `-nifti` suffix, because `actions/cache` does not re-save on a hit: without the bump the newly required files would be re-downloaded on every run instead of once. **Drop that hunk if you would rather pay the download than invalidate the cache** — the rest of the change works either way.

### Verification

- 14/14 pass locally, over 166 `.nii` files.
- Negative control: the assertion rejects a missing RAS flip, a 0.1 mm origin shift, and a slice-direction sign flip. It is discriminating, not vacuous.
- Suite: **2124 passed, 12 skipped, no failures** — the 5 long-standing red cases are gone and 9 net new checks replace them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuK1cZi8U54WXAdXMmGpzy