### PR TITLE
`JCAMPDX` has `keys()` and `__getitem__` but no `__iter__` — `for key…

### DIFF
--- a/brukerapi/jcampdx.py
+++ b/brukerapi/jcampdx.py
@@ -704,6 +704,12 @@ class JCAMPDX:
     def __getitem__(self, key):
         return self.params[key]
 
+    def __iter__(self):
+        return iter(self.params)
+
+    def __len__(self):
+        return len(self.params)
+
     def __contains__(self, item):
         return item in self.params
 

--- a/test/test_jcampdx.py
+++ b/test/test_jcampdx.py
@@ -48,6 +48,26 @@ def test_jcampdx(test_jcampdx_data):
             assert value_ref == value_test
 
 
+def test_jcampdx_iteration_and_length_follow_its_mapping_interface(tmp_path):
+    path = tmp_path / "visu_pars"
+    path.write_text(
+        "##TITLE=Parameter List\n"
+        "##JCAMPDX=4.24\n"
+        "##DATATYPE=Parameter Values\n"
+        "##$VisuCoreDim=2\n"
+        "##END=\n"
+    )
+    jcamp = JCAMPDX(path)
+
+    assert list(jcamp) == list(jcamp.keys())
+    assert len(jcamp) == len(jcamp.keys())
+    assert dict(jcamp) == {key: jcamp[key] for key in jcamp}
+
+    jcamp.unload()
+    assert list(jcamp) == []
+    assert len(jcamp) == 0
+
+
 def test_a_string_is_read_without_its_delimiters():
     """Spec 2.2: `<...>` delimits a string, so the brackets are not its value.
 


### PR DESCRIPTION
… in jcampdx` raises `KeyError: 0`

Fixes #184