### PR TITLE
Folder defines `__getitem__` but no `__iter__`, so `for x in folder` raises `KeyError: 0`

### DIFF
--- a/brukerapi/folders.py
+++ b/brukerapi/folders.py
@@ -136,6 +136,15 @@ class Folder:
         except AttributeError:
             raise KeyError(f"Child '{name}' not found in {self.path}") from None
 
+    #: A folder is not iterable. Without this, ``__getitem__`` above would make
+    #: Python fall back to the legacy iteration protocol, call ``self[0]`` and
+    #: raise ``KeyError: 0`` -- an error that points at the tree rather than at
+    #: the loop. Iterating a folder is also ambiguous, because ``__getitem__``
+    #: takes a child *name* while the obvious result is the child *objects*.
+    #: Use :attr:`children`, or one of the ``get_*_list`` methods, which say
+    #: which of the two is wanted.
+    __iter__ = None
+
     def query(self, query):
         """Query each dataset in the folder recursively.
 

--- a/test/test_folders.py
+++ b/test/test_folders.py
@@ -6,7 +6,14 @@ import numpy as np
 import pytest
 
 from brukerapi.dataset import Dataset
-from brukerapi.folders import DEFAULT_DATASET_STATE, Folder, Processing, Study, TypeFilter
+from brukerapi.folders import (
+    DEFAULT_DATASET_STATE,
+    Experiment,
+    Folder,
+    Processing,
+    Study,
+    TypeFilter,
+)
 from test.synthetic import Verbatim, write_binary, write_jcampdx
 
 PV51_STUDY_PATH = Path("test/test_data/PV51/0.2H2")
@@ -29,6 +36,28 @@ def test_folder_attribute_miss_supports_hasattr_deepcopy_and_pickle(tmp_path):
     assert restored.path == folder.path
     assert [child.path.name for child in copied.children] == [child.path.name for child in folder.children]
     assert [child.path.name for child in restored.children] == [child.path.name for child in folder.children]
+
+
+def test_folder_is_not_iterable_and_points_at_children(tmp_path):
+    """`__getitem__` must not make a folder iterable by the legacy protocol.
+
+    Without an explicit opt out, `for child in folder` calls `folder[0]`, which
+    misses and raises `KeyError: 0` against a name-keyed tree. `children` is the
+    route that says whether names or objects are wanted.
+    """
+    (tmp_path / "child").mkdir()
+
+    for cls in (Folder, Study, Experiment, Processing):
+        assert cls.__iter__ is None, f"{cls.__name__} must opt out of iteration"
+
+    folder = Folder(tmp_path)
+    with pytest.raises(TypeError, match="not iterable"):
+        iter(folder)
+    with pytest.raises(TypeError, match="not iterable"):
+        list(folder)
+
+    assert [child.path.name for child in folder.children] == ["child"]
+    assert folder["child"] is folder.children[0]
 
 
 def test_type_filter_forwards_nondefault_filter_options(tmp_path):


### PR DESCRIPTION
`Folder.__getitem__` looks a child up by name. Because it exists and `__iter__` does not, Python falls back to the legacy iteration protocol: `for child in folder` calls `folder[0]`, misses in the name-keyed `_children_map`, and raises `KeyError: 0`.

```python
>>> study = Study(".../20200612_094625_study_1_1")
>>> study["8"]                      # by name, works
<brukerapi.folders.Experiment ...>
>>> for experiment in study: ...
KeyError: 0
```

The message points at the tree rather than at the loop, so it reads like a damaged dataset. That is the same trap as #184.

## Why the answer is the opposite of #184

There, iteration had one obvious meaning — parameter names, matching `keys()` — so adding `__iter__` was right, and you did.

A folder has two meanings, and they disagree:

- `__getitem__` takes a child **name**, so the mapping reading yields names.
- `for child in study` plainly reads as the child **objects**.

Whichever is chosen, the people who assumed the other one get silently wrong results instead of an error — worse than the current crash. And nothing is gained: `children` already returns the objects, while `get_dataset_list`, `get_experiment_list`, `get_processing_list` and `get_study_list` name the subset wanted. Iteration would add a coin flip, not a capability.

Unlike `JCAMPDX`, these classes have no `keys()` and no `__contains__`, so there is no mapping contract pulling the decision either way.

## The change

`__iter__ = None` on `Folder`, which is the documented way to opt out. `Study`, `Experiment` and `Processing` inherit it.

```python
>>> for experiment in study: ...
TypeError: 'Study' object is not iterable
```

The error now names the type and sends the reader to `children`. This refuses an operation that already failed, so no working code changes: nothing in `brukerapi/`, `test/` or `examples/` iterates a folder.

If you would rather have iteration than an honest error, I am happy to send that instead — but then it needs a documented choice between names and objects, and `children` already covers the objects case.

## Checks

`ruff check .` clean on the pinned 0.16.0. Full suite run against a local corpus: 241 passed, 51 skipped. Four `test_dataset.py` failures are pre-existing on `master` with the same corpus (`FileNotFoundError` on fixtures I do not have) and are unrelated to this change.
