### PR TITLE
Give `Dataset` `keys()` and `__iter__`, so the names `__getitem__` reaches can be listed

### DIFF
--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -326,6 +326,31 @@ class Dataset:
     def __contains__(self, item):
         return any(item in parameter_file for parameter_file in self._parameters.values())
 
+    def keys(self):
+        """Every parameter name reachable through ``[]``, listed once.
+
+        A data set merges several JCAMP-DX files, and ``__getitem__`` returns
+        the first file that holds the name. A name carried by more than one
+        file therefore denotes one reachable value, and is listed once, in the
+        order the files are searched.
+
+        :raises :obj:`.ParametersNotLoaded`: if the parameters are not loaded
+        """
+        names = {}
+        for parameter_file in self.parameters.values():
+            names.update(dict.fromkeys(parameter_file))
+        return names.keys()
+
+    def __iter__(self):
+        """Iterate the parameter names, so ``dict(dataset)`` matches ``[]``.
+
+        There is deliberately no ``__len__``: a data set is an image first, so
+        ``len(dataset)`` would read as a count of frames rather than of
+        parameters. Use ``len(dataset.keys())`` for the parameter count, and
+        :attr:`shape` for the data.
+        """
+        return iter(self.keys())
+
     def __call__(self, **kwargs):
         self._set_state(kwargs)
         return self

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -11,7 +11,7 @@ import pytest
 
 from brukerapi.cli import report as cli_report
 from brukerapi.dataset import LOAD_STAGES, Dataset
-from brukerapi.exceptions import FilterEvalFalse, IncompleteDataset, InvalidDataset, TrajNotLoaded, UnknownAcqSchemeException, UnsupportedDatasetType
+from brukerapi.exceptions import FilterEvalFalse, IncompleteDataset, InvalidDataset, ParametersNotLoaded, TrajNotLoaded, UnknownAcqSchemeException, UnsupportedDatasetType
 from brukerapi.schemas import Schema2dseq, SchemaFid, SchemaRawdata
 from test.synthetic import write_2dseq, write_jcampdx
 
@@ -1183,3 +1183,37 @@ def test_add_parameters_loads_the_named_parameter_file(tmp_path):
     assert "subject" in dataset.parameters
     assert dataset["SUBJECT_id"].value == "lego_phantom_3"
     assert dataset.metadata["subject"]["id"] == "lego_phantom_3"
+
+
+def test_dataset_iteration_lists_the_names_getitem_can_reach(tmp_path):
+    """`__getitem__` searches several files, so iteration must list the union.
+
+    A name carried by more than one file resolves to one value -- the first
+    file searched wins -- so it is listed once, and `dict(dataset)` agrees with
+    `[]` for every name.
+    """
+    study = tmp_path / "20200612_094625_study_1_1"
+    write_jcampdx(study / "subject", {"SUBJECT_id": ["<phantom>"], "SUBJECT_study_nr": 2})
+    path = write_2dseq(study / "8" / "pdata" / "1")
+
+    dataset = Dataset(path, add_parameters=["subject"], load=LOAD_STAGES["parameters"])
+
+    names = list(dataset)
+    assert names == list(dataset.keys())
+    assert len(names) == len(set(names)), "a shadowed name must be listed once"
+    assert set(names) == {name for parameters in dataset.parameters.values() for name in parameters}
+
+    # Both files carry the JCAMP-DX preamble, so the fixture really does shadow
+    # and the check above is not vacuous.
+    assert len(names) < sum(len(parameters) for parameters in dataset.parameters.values())
+    assert all(name in dataset for name in names)
+    assert dict(dataset) == {name: dataset[name] for name in names}
+
+    # TITLE is written by every JCAMP-DX file, so it is the shadowed case.
+    assert "TITLE" in names
+    first_file = next(iter(dataset.parameters.values()))
+    assert dataset["TITLE"] is first_file["TITLE"]
+
+    dataset.unload_parameters()
+    with pytest.raises(ParametersNotLoaded):
+        list(dataset)


### PR DESCRIPTION
`Dataset.__getitem__` searches the merged parameter files and returns the first hit, and `__contains__` asks the same question of the same union. But there is no way to ask *which* names are reachable.

A caller who wants that has to reach past the accessor, back into `dataset.parameters`, and merge the files again — which means getting the shadowing rule right by hand:

```python
# today
names = {name for parameters in dataset.parameters.values() for name in parameters}

# with this change
names = dataset.keys()
```

## The change

`keys()` returns the union, listed once, in the order the files are searched, so it agrees with `__getitem__` for every name it yields. `__iter__` follows it, which makes `dict(dataset)` and `{**dataset}` behave, and matches what `JCAMPDX` gained in #184.

```python
>>> len(dataset.keys())
279
>>> dict(dataset) == {name: dataset[name] for name in dataset}
True
```

## Two decisions worth reviewing

**Shadowing.** On a real 2dseq, 5 of 279 names sit in more than one file — `TITLE`, `JCAMPDX`, `DATATYPE`, `ORIGIN`, `OWNER`, the JCAMP-DX preamble every file carries. `__getitem__` already resolves those to the first file searched, so listing such a name once is what makes `keys()` and `[]` agree. The test builds a study whose `visu_pars` and `subject` share that preamble, so the deduplication is exercised rather than assumed.

**No `__len__`.** A data set is an image first, so `len(dataset)` would read as a count of frames rather than of parameters. `shape` answers the former and `len(dataset.keys())` the latter, and neither is ambiguous. `JCAMPDX` is only parameters, so `__len__` was unambiguous there and I did not carry it across. Say the word if you would rather have it for symmetry.

One smaller note: with parameters unloaded, `keys()` raises `ParametersNotLoaded`, matching the `parameters` property. `__getitem__` currently leaks an `AttributeError` from `None.values()` in that state — I have left that alone rather than widen this PR, but it is worth a look.

## Checks

`ruff check .` clean on the pinned 0.16.0. Full suite run against a local corpus: 241 passed, 51 skipped. Four `test_dataset.py` failures are pre-existing on `master` with the same corpus (`FileNotFoundError` on fixtures I do not have) and are unrelated to this change.

This is an enhancement rather than a bug fix, and it is independent of the `Folder` PR — that one argues iteration should be refused, this one that it is well defined. Both branch from `master`.
