### PR TITLE
Read the JCAMP-DX version as a version, not as the whole record line

### DIFF
--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -245,11 +245,7 @@ class Dataset:
                 (name for name in content if re.fullmatch(r"rawdata\.job\d+", name)),
                 key=lambda name: int(name.rsplit("job", 1)[1]),
             )
-            named_rawdata_jobs = sorted(
-                name
-                for name in content
-                if name not in rawdata_jobs and self.is_supported_path(self.path / name, {"rawdata"})
-            )
+            named_rawdata_jobs = sorted(name for name in content if name not in rawdata_jobs and self.is_supported_path(self.path / name, {"rawdata"}))
             if "fid" in content:
                 self.path = self.path / "fid"
             elif "2dseq" in content:
@@ -273,10 +269,7 @@ class Dataset:
         if self.type not in DEFAULT_STATES:
             raise UnsupportedDatasetType(self.type)
         if self.type == "fid" and self.subtype in FID_COMPANION_SUBTYPES and not state.get("_auxiliary"):
-            raise UnsupportedDatasetType(
-                f"{self.path.name} is a fid companion (spec §3.5); load it as "
-                f"Dataset({with_suffix(self.path, '')!s}).fid_companions[{self.subtype!r}]"
-            )
+            raise UnsupportedDatasetType(f"{self.path.name} is a fid companion (spec §3.5); load it as Dataset({with_suffix(self.path, '')!s}).fid_companions[{self.subtype!r}]")
         if not self._is_supported_subtype() and not (state.get("_auxiliary") and self.type == "fid" and self.subtype in FID_COMPANION_SUBTYPES):
             raise UnsupportedDatasetType(self.path.name)
 
@@ -596,9 +589,9 @@ class Dataset:
         A name no configuration declares still raises, so a typo does not
         quietly become `default`::
 
-            dataset.get("TE")           # 4.0, or None where there is no echo time
-            dataset.get("TE", "n/a")    # 4.0, or "n/a"
-            dataset.get("TEE")          # AttributeError
+            dataset.get("TE")  # 4.0, or None where there is no echo time
+            dataset.get("TE", "n/a")  # 4.0, or "n/a"
+            dataset.get("TEE")  # AttributeError
 
         Parameters are a separate layer, read with ``dataset[key]`` or
         ``dataset.parameters``.
@@ -727,8 +720,7 @@ class Dataset:
         settings_stored = int(settings[9])
         if settings_stored != job_stored and not getattr(self, "_warned_rawdata_stored_scans", False):
             warnings.warn(
-                f"ACQ_ScanPipeJobSettings nStoredScans={settings_stored} disagrees with "
-                f"ACQ_jobs nStoredScans={job_stored} for {self.path}; using the settings value",
+                f"ACQ_ScanPipeJobSettings nStoredScans={settings_stored} disagrees with ACQ_jobs nStoredScans={job_stored} for {self.path}; using the settings value",
                 RuntimeWarning,
                 stacklevel=2,
             )
@@ -779,9 +771,7 @@ class Dataset:
         if descriptions and descriptions[0] == "Spectroscopic":
             return "SPECTROSCOPY" if int(dim) == 1 else "CSI"
 
-        if n_projections is not None and int(n_projections) > 0 and (
-            (self.path.parent / "traj").exists() or "RADIAL" in family or "UTE" in family
-        ):
+        if n_projections is not None and int(n_projections) > 0 and ((self.path.parent / "traj").exists() or "RADIAL" in family or "UTE" in family):
             return "RADIAL"
 
         acq_size = np.atleast_1d(self._parameter_value("ACQ_size", []))
@@ -940,9 +930,7 @@ class Dataset:
                     f"expected {expected_bytes} bytes for shape {tuple(shape)} and dtype {dtype}"
                 )
 
-            raise InvalidDataset(
-                f"Invalid dataset size at {path}: expected {expected_bytes} bytes for shape {tuple(shape)} and dtype {dtype}, got {actual_bytes} bytes"
-            )
+            raise InvalidDataset(f"Invalid dataset size at {path}: expected {expected_bytes} bytes for shape {tuple(shape)} and dtype {dtype}, got {actual_bytes} bytes")
 
         return read_array(path, dtype, shape)
 
@@ -1343,9 +1331,7 @@ class Dataset:
         """
         descriptors = np.atleast_1d(np.asarray(self._parameter_value("VisuCoreDimDesc", []))).astype(str)
         if descriptors.size and any(descriptor != "spatial" for descriptor in descriptors):
-            raise UnsupportedDatasetType(
-                f"an image affine for {self.path}, whose frames are {sorted(set(descriptors))} rather than purely spatial (spec 7.2),"
-            )
+            raise UnsupportedDatasetType(f"an image affine for {self.path}, whose frames are {sorted(set(descriptors))} rather than purely spatial (spec 7.2),")
         if len(self.slice_packages_index()) > 1:
             warnings.warn(
                 f"{self.path} has multiple slice packages; a single affine cannot describe them -- use get_slice_packages() / affine_of_package(i)",

--- a/brukerapi/jcampdx.py
+++ b/brukerapi/jcampdx.py
@@ -8,7 +8,10 @@ import numpy as np
 from .exceptions import InvalidJcampdxFile, JcampdxFileError, JcampdxVersionError, ParameterNotFound
 from .paths import as_path
 
-SUPPORTED_VERSIONS = ["4.24", "5.0", "5.00 Bruker JCAMP library", "5.00 BRUKER JCAMP library", "5.01"]
+# Spec 2.1: parameter lists are 4.24; the spnamN shape files are JCAMP-DX 5.00.
+# These are version numbers only -- whatever Bruker appends to the record is a
+# library identification or a `$$` comment, and is stripped before the check.
+SUPPORTED_VERSIONS = ["4.24", "5.0", "5.00", "5.01"]
 GRAMMAR = {
     "COMMENT_LINE": r"\$\$[^\n]*\n",
     "PARAMETER": r"^##",
@@ -756,7 +759,7 @@ class JCAMPDX:
 
         for key in ("JCAMPDX", "JCAMP-DX"):
             if key in self.params:
-                return self.params[key].value
+                return self.parse_version(self.params[key].value)
 
         try:
             with self.path.open("r") as f:
@@ -879,17 +882,30 @@ class JCAMPDX:
     @classmethod
     def verify_version(cls, version):
         if isinstance(version, str):
-            version = version.strip()
+            version = cls.parse_version(version)
         if version not in SUPPORTED_VERSIONS:
             raise JcampdxVersionError(version)
 
     @staticmethod
-    def _detect_version(lines):
+    def parse_version(value):
+        """The version number out of a ``##JCAMP-DX=`` record's value.
+
+        Spec 2.1: ``$$`` starts a JCAMP-DX comment, and ParaVision writes one on
+        this very record -- a real `spnam1` carries
+        ``##JCAMP-DX= 5.00 $$ BRUKER JCAMP library (alpha version)``.  Bruker also
+        appends a bare library identification (``5.00 Bruker JCAMP library``).
+        Neither is part of the version, so take the first token and leave the rest
+        as what it is: a comment.
+        """
+        return str(value).split("$$", 1)[0].strip().split(maxsplit=1)[0] if str(value).strip() else ""
+
+    @classmethod
+    def _detect_version(cls, lines):
         for index, line in enumerate(lines):
             if index >= 10:
                 break
             if line.startswith(("##JCAMPDX=", "##JCAMP-DX=")):
-                return line.split("=", 1)[1].strip()
+                return cls.parse_version(line.split("=", 1)[1])
         return None
 
     @classmethod

--- a/brukerapi/schemas.py
+++ b/brukerapi/schemas.py
@@ -51,7 +51,7 @@ REQUIRED_PROPERTIES = {
         "k_space",
         "encoded_dim",
         "shape_storage",
-        "dim_type"
+        "dim_type",
     ],
     "2dseq": [
         "pv_version",
@@ -223,9 +223,7 @@ class SchemaFid(Schema):
             for name in ("encoding_space", "k_space"):
                 logical_samples = int(np.prod(layouts[name]))
                 if stored_samples % logical_samples:
-                    raise InvalidDataset(
-                        f"real-only AQ_mod=qf sample count {stored_samples} is incompatible with {name} layout {layouts[name]}"
-                    )
+                    raise InvalidDataset(f"real-only AQ_mod=qf sample count {stored_samples} is incompatible with {name} layout {layouts[name]}")
                 ratio = stored_samples // logical_samples
                 if ratio > 1:
                     layouts[name] = (layouts[name][0] * ratio,) + tuple(layouts[name][1:])
@@ -282,10 +280,7 @@ class SchemaFid(Schema):
         data = self._decode_raw_stream(stored, self.layouts)
         receivers = int(self._dataset.channels)
         if data.shape[0] % receivers:
-            raise InvalidDataset(
-                f"decoded FID sample count {data.shape[0]} is not divisible by "
-                f"the receiver count {receivers} for {self._dataset.path}"
-            )
+            raise InvalidDataset(f"decoded FID sample count {data.shape[0]} is not divisible by the receiver count {receivers} for {self._dataset.path}")
         samples = data.shape[0] // receivers
         return np.transpose(
             np.reshape(data, (samples, receivers, data.shape[1]), order="F"),
@@ -302,9 +297,7 @@ class SchemaFid(Schema):
         try:
             axes = tuple(BART_DIM_BY_TYPE[label] for label in self._dataset.dim_type)
         except KeyError as error:
-            raise UnknownAcqSchemeException(
-                f"cannot map FID axis {error.args[0]!r} to BART for {self._dataset.path}"
-            ) from error
+            raise UnknownAcqSchemeException(f"cannot map FID axis {error.args[0]!r} to BART for {self._dataset.path}") from error
         return self._as_bart(data, axes)
 
     def _reorder_objects(self, data, dir="FW"):
@@ -391,9 +384,7 @@ class SchemaFid(Schema):
             PVM_EncSteps1_sorted = self.permutation_inverse(PVM_EncSteps1_sorted)
 
         if data.shape[1] != len(PVM_EncSteps1_sorted):
-            raise InvalidDataset(
-                f"phase-encode reorder length {len(PVM_EncSteps1_sorted)} does not match k-space axis length {data.shape[1]} for scheme {self._dataset.scheme_id}"
-            )
+            raise InvalidDataset(f"phase-encode reorder length {len(PVM_EncSteps1_sorted)} does not match k-space axis length {data.shape[1]} for scheme {self._dataset.scheme_id}")
 
         if np.array_equal(PVM_EncSteps1_sorted, np.arange(len(PVM_EncSteps1_sorted))):
             return data
@@ -712,17 +703,13 @@ class SchemaRawdata(Schema):
         scheme_id = self._dataset._infer_scheme_id()
         if scheme_id is not None:
             raise UnknownAcqSchemeException(
-                f"rawdata-to-k-space is currently supported only for Cartesian PV-360 jobs, "
-                f"but {self._dataset.path} is {scheme_id}; use its acquisition-specific reader"
+                f"rawdata-to-k-space is currently supported only for Cartesian PV-360 jobs, but {self._dataset.path} is {scheme_id}; use its acquisition-specific reader"
             )
 
         encoded_dim = self._dataset._parameter_value("ACQ_dim")
         matrix = np.atleast_1d(self._dataset._parameter_value("PVM_EncMatrix", []))
         if encoded_dim not in (2, 3) or matrix.size < encoded_dim:
-            raise UnknownAcqSchemeException(
-                f"cannot establish a Cartesian rawdata layout for {self._dataset.path}; "
-                "pass data through an acquisition-specific reader"
-            )
+            raise UnknownAcqSchemeException(f"cannot establish a Cartesian rawdata layout for {self._dataset.path}; pass data through an acquisition-specific reader")
 
         matrix = tuple(int(value) for value in matrix[:encoded_dim])
         receivers = int(self._dataset.channels)
@@ -747,22 +734,15 @@ class SchemaRawdata(Schema):
             permute = (0, 2, 3, 4, 1)
         else:
             if objects != 1:
-                raise UnknownAcqSchemeException(
-                    f"cannot establish a 3-D Cartesian rawdata layout with NI={objects} for "
-                    f"{self._dataset.path}"
-                )
+                raise UnknownAcqSchemeException(f"cannot establish a 3-D Cartesian rawdata layout with NI={objects} for {self._dataset.path}")
             encoding_space = (readout, receivers, phase, matrix[2], repetitions)
             permute = (0, 2, 3, 4, 1)
 
         if data.ndim != 3 or data.shape[0] != readout or data.shape[1] != receivers:
-            raise InvalidDataset(
-                f"rawdata sample layout {data.shape} does not match Cartesian metadata "
-                f"(readout={readout}, receivers={receivers}) for {self._dataset.path}"
-            )
+            raise InvalidDataset(f"rawdata sample layout {data.shape} does not match Cartesian metadata (readout={readout}, receivers={receivers}) for {self._dataset.path}")
         if data.size != int(np.prod(encoding_space)):
             raise InvalidDataset(
-                f"rawdata contains {data.size} complex samples but Cartesian layout {encoding_space} "
-                f"requires {int(np.prod(encoding_space))} for {self._dataset.path}"
+                f"rawdata contains {data.size} complex samples but Cartesian layout {encoding_space} requires {int(np.prod(encoding_space))} for {self._dataset.path}"
             )
 
         k_space = np.transpose(np.reshape(data, encoding_space, order="F"), permute)
@@ -779,10 +759,7 @@ class SchemaRawdata(Schema):
         """Arrange retrospectively gated Cartesian data before cine binning."""
         steps = np.atleast_1d(self._dataset._parameter_value("PVM_EncGenSteps1", []))
         if steps.size == 0 or steps.size % phase:
-            raise InvalidDataset(
-                f"self-gated phase-encode sequence has {steps.size} steps, which is incompatible "
-                f"with phase size {phase} for {self._dataset.path}"
-            )
+            raise InvalidDataset(f"self-gated phase-encode sequence has {steps.size} steps, which is incompatible with phase size {phase} for {self._dataset.path}")
         acquired_frames = steps.size // phase
         output_frames = int(self._dataset._parameter_value("PVM_NMovieFrames", objects))
         if output_frames != objects or acquired_frames % (objects * repetitions):
@@ -793,10 +770,7 @@ class SchemaRawdata(Schema):
         acquisition_cycles = acquired_frames // (objects * repetitions)
         layout = (readout, receivers, phase, acquired_frames)
         if data.ndim != 3 or data.shape[0] != readout or data.shape[1] != receivers or data.size != int(np.prod(layout)):
-            raise InvalidDataset(
-                f"rawdata sample layout {data.shape} does not match self-gated Cartesian layout "
-                f"{layout} for {self._dataset.path}"
-            )
+            raise InvalidDataset(f"rawdata sample layout {data.shape} does not match self-gated Cartesian layout {layout} for {self._dataset.path}")
 
         k_space = np.transpose(np.reshape(data, layout, order="F"), (0, 2, 3, 1))
         order = np.argsort(np.reshape(steps, (phase, acquired_frames), order="F"), axis=0)
@@ -813,10 +787,7 @@ class SchemaRawdata(Schema):
             return data
         indices = np.argsort(np.atleast_1d(steps))
         if indices.size != data.shape[1]:
-            raise InvalidDataset(
-                f"phase-encode reorder length {indices.size} does not match k-space axis length "
-                f"{data.shape[1]} for {self._dataset.path}"
-            )
+            raise InvalidDataset(f"phase-encode reorder length {indices.size} does not match k-space axis length {data.shape[1]} for {self._dataset.path}")
         return np.take(data, indices, axis=1)
 
     def _reorder_objects(self, data):
@@ -827,11 +798,9 @@ class SchemaRawdata(Schema):
             return data
         indices = np.argsort(np.atleast_1d(order).astype(int))
         if indices.size != data.shape[2]:
-            raise InvalidDataset(
-                f"object-order length {indices.size} does not match k-space axis length "
-                f"{data.shape[2]} for {self._dataset.path}"
-            )
+            raise InvalidDataset(f"object-order length {indices.size} does not match k-space axis length {data.shape[2]} for {self._dataset.path}")
         return np.take(data, indices, axis=2)
+
 
 class Schema2dseq(Schema):
     """
@@ -948,8 +917,7 @@ class Schema2dseq(Schema):
             axis = 2
         if axis is None or axis >= data.ndim:
             warnings.warn(
-                "VisuCoreDiskSliceOrder requests reversed slices but no slice axis is identifiable "
-                f"for {getattr(self._dataset, 'path', '<unknown>')}; leaving order unchanged",
+                f"VisuCoreDiskSliceOrder requests reversed slices but no slice axis is identifiable for {getattr(self._dataset, 'path', '<unknown>')}; leaving order unchanged",
                 RuntimeWarning,
                 stacklevel=2,
             )
@@ -974,9 +942,7 @@ class Schema2dseq(Schema):
             # component: there is nothing to combine, keep the axis as it is
             return None
         if data.shape[axis] != 2:
-            raise InvalidDataset(
-                f"complex 2dseq requires a two-element real/imag frame-group axis, got shape {data.shape} on axis {axis}"
-            )
+            raise InvalidDataset(f"complex 2dseq requires a two-element real/imag frame-group axis, got shape {data.shape} on axis {axis}")
         return axis
 
     def _combine_complex_frames(self, data):
@@ -1100,9 +1066,7 @@ class Schema2dseq(Schema):
         # Frame-group selection above does not alter encoded dimensions.
         # Apply their requested selection after deserializing the selected
         # frames, preserving singleton axes for the final squeeze below.
-        encoded_slice = tuple(
-            slice(index, index + 1) if isinstance(index, int) else index for index in slice_[: self._dataset.encoded_dim]
-        )
+        encoded_slice = tuple(slice(index, index + 1) if isinstance(index, int) else index for index in slice_[: self._dataset.encoded_dim])
         array_ra = array_ra[encoded_slice + (slice(None),) * (array_ra.ndim - self._dataset.encoded_dim)]
 
         singletons = tuple(i for i, v in enumerate(slice_) if isinstance(v, int))

--- a/examples/read_2dseq.ipynb
+++ b/examples/read_2dseq.ipynb
@@ -259,8 +259,8 @@
     "print(dataset.TE)\n",
     "print(dataset.TR)\n",
     "print(dataset.imaging_frequency)\n",
-    "print(dataset.frame_group_values.get('VisuAcqEchoTime'))\n",
-    "print(dataset.metadata['visu_acq'].get('sequence_name'))"
+    "print(dataset.frame_group_values.get(\"VisuAcqEchoTime\"))\n",
+    "print(dataset.metadata[\"visu_acq\"].get(\"sequence_name\"))"
    ]
   }
  ],

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -78,8 +78,7 @@ def pytest_sessionstart(session):
 
     if _available_test_data_root() is None:
         pytest.exit(
-            "No Bruker test-data corpus is available. Provide test/test_data or resources/testdata, "
-            "or run pytest with --download_test_data.",
+            "No Bruker test-data corpus is available. Provide test/test_data or resources/testdata, or run pytest with --download_test_data.",
             returncode=1,
         )
 

--- a/test/loadtest.py
+++ b/test/loadtest.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+"""Empirical load-test harness for brukerapi against resources/testdata.
+
+Walks the testdata tree, finds every supported binary file (fid, 2dseq, rawdata.jobN,
+traj, ser), attempts to construct a brukerapi.Dataset for it, and records the outcome:
+success (+shape/dtype) or failure (+exception type + short message).
+"""
+
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+from brukerapi.dataset import Dataset
+
+ROOT = Path("resources/testdata").resolve()
+
+# Binary stems brukerapi claims to support (see DEFAULT_STATES)
+SUPPORTED_STEMS = {"fid", "2dseq", "rawdata", "traj", "ser"}
+
+
+def classify(p: Path):
+    stem = p.name.split(".")[0]
+    return stem
+
+
+def find_targets(root: Path):
+    targets = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # skip git internals and provenance
+        parts = set(Path(dirpath).parts)
+        if ".git" in parts or "_sources" in parts:
+            dirnames[:] = [d for d in dirnames if d != ".git"]
+            continue
+        for fn in filenames:
+            stem = fn.split(".")[0]
+            if stem in SUPPORTED_STEMS:
+                targets.append(Path(dirpath) / fn)
+    return sorted(targets)
+
+
+def try_load(path: Path):
+    rec = {"path": str(path.relative_to(ROOT)), "stem": classify(path), "size": path.stat().st_size}
+    try:
+        ds = Dataset(str(path))
+        rec["ok"] = True
+        try:
+            rec["shape"] = list(ds.data.shape)
+            rec["dtype"] = str(ds.data.dtype)
+        except Exception as e:
+            rec["ok"] = False
+            rec["stage"] = "data-access"
+            rec["err"] = f"{type(e).__name__}: {e}"
+        return rec
+    except Exception as e:
+        rec["ok"] = False
+        rec["err_type"] = type(e).__name__
+        rec["err"] = str(e)[:300]
+        rec["tb"] = traceback.format_exc()[-1500:]
+        return rec
+
+
+def main():
+    targets = find_targets(ROOT)
+    results = [try_load(p) for p in targets]
+
+    ok = [r for r in results if r.get("ok")]
+    bad = [r for r in results if not r.get("ok")]
+
+    print(f"TOTAL targets: {len(results)}  OK: {len(ok)}  FAIL: {len(bad)}")
+    print("\n=== FAILURE COUNTS BY (stem, err_type) ===")
+    from collections import Counter
+
+    c = Counter((r["stem"], r.get("err_type", r.get("stage", "?"))) for r in bad)
+    for (stem, et), n in c.most_common():
+        print(f"  {n:4d}  {stem:8s} {et}")
+
+    print("\n=== OK COUNTS BY stem ===")
+    c2 = Counter(r["stem"] for r in ok)
+    for stem, n in c2.most_common():
+        print(f"  {n:4d}  {stem}")
+
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/tmp/loadtest_results.json")
+    out.write_text(json.dumps(results, indent=2))
+    print(f"\nFull results -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -768,10 +768,7 @@ def test_recipe_substitution_preserves_overlapping_identifiers():
 
     substituted = dataset._sub_parameters(recipe)
 
-    assert substituted == (
-        "self.Foo + self.FooBar + self['X'].value + "
-        "self['XY'].value + self['Matrix'].tuple"
-    )
+    assert substituted == ("self.Foo + self.FooBar + self['X'].value + self['XY'].value + self['Matrix'].tuple")
 
 
 @pytest.mark.parametrize(
@@ -1033,10 +1030,7 @@ def test_frame_group_values_align_echo_times_and_diffusion_matrices_to_data_axes
             continue
         candidate = Dataset(path)
         try:
-            if (
-                "VisuAcqEchoTime" in candidate.frame_group_values
-                and np.atleast_1d(candidate["VisuAcqEchoTime"].value).size > 1
-            ):
+            if "VisuAcqEchoTime" in candidate.frame_group_values and np.atleast_1d(candidate["VisuAcqEchoTime"].value).size > 1:
                 echo = candidate
                 break
         except KeyError:
@@ -1123,11 +1117,7 @@ def test_data_load(test_data):
             reference = np.transpose(reference, (0, 2, 1))
         if dataset.type == "2dseq" and np.iscomplexobj(actual) and not np.iscomplexobj(reference):
             complex_axis = next(
-                (
-                    axis
-                    for axis, dim_type in enumerate(dataset.dim_type)
-                    if str(dim_type).upper() == "FG_COMPLEX"
-                ),
+                (axis for axis, dim_type in enumerate(dataset.dim_type) if str(dim_type).upper() == "FG_COMPLEX"),
                 None,
             )
             if complex_axis is None:

--- a/test/test_geometry.py
+++ b/test/test_geometry.py
@@ -19,9 +19,7 @@ SAGITTAL_ORIENTATION = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, 0.0])
 PV360_NIFTI_ROOT = Path("test/test_data/PV360_StdData")
 # Every reconstruction that ships a NIfTI export, rather than a fixed list, so
 # a dataset added to the corpus is checked without editing this file.
-PV360_NIFTI_EXPORTS = sorted(
-    directory.parent.relative_to(PV360_NIFTI_ROOT).as_posix() for directory in PV360_NIFTI_ROOT.glob("*/pdata/*/nifti") if any(directory.glob("*.nii"))
-)
+PV360_NIFTI_EXPORTS = sorted(directory.parent.relative_to(PV360_NIFTI_ROOT).as_posix() for directory in PV360_NIFTI_ROOT.glob("*/pdata/*/nifti") if any(directory.glob("*.nii")))
 
 
 def nifti_affine(path):

--- a/test/test_jcampdx.py
+++ b/test/test_jcampdx.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from brukerapi.exceptions import InvalidJcampdxFile
+from brukerapi.exceptions import InvalidJcampdxFile, JcampdxVersionError
 from brukerapi.jcampdx import JCAMPDX, DataParameter, GenericParameter
 
 
@@ -602,3 +602,39 @@ def test_a_malformed_record_raises_a_typed_error(tmp_path):
         _ = parameters["SHORT"].value
     with pytest.raises(InvalidJcampdxFile, match="is not an integer"):
         _ = parameters["BADSIZE"].size
+
+
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        ("##JCAMPDX=4.24", "4.24"),
+        ("##JCAMPDX= 5.0", "5.0"),
+        ("##JCAMP-DX= 5.00 Bruker JCAMP library", "5.00"),
+        ("##JCAMP-DX= 5.00 BRUKER JCAMP library", "5.00"),
+        ("##JCAMP-DX= 5.00 $$ BRUKER JCAMP library (alpha version)", "5.00"),
+    ],
+)
+def test_the_version_record_is_read_as_a_version_not_as_a_whole_line(tmp_path, record, expected):
+    """Spec 2.1: `$$` starts a comment, so it is not part of the version.
+
+    ParaVision writes one on this very record -- a real `spnam1` in the PV6 and
+    PV7 studies carries `##JCAMP-DX= 5.00 $$ BRUKER JCAMP library (alpha
+    version)` -- and also appends a bare library identification. Matching the
+    whole line tail against a list of literals rejected the `$$` form, which
+    `Folder` then dropped silently.
+    """
+    path = tmp_path / "spnam1"
+    path.write_text(f"##TITLE= /d/exp/stan/nmr/lists/wave/bp\n{record}\n##DATA TYPE= Shape Data\n##$SHAPE_TOTROT=1.8e+02\n##END=\n")
+
+    parameters = JCAMPDX(path)
+
+    assert parameters.version == expected
+    assert parameters["SHAPE_TOTROT"].value == 180.0
+
+
+def test_an_unsupported_version_is_still_rejected(tmp_path):
+    path = tmp_path / "spnam1"
+    path.write_text("##TITLE=Shape\n##JCAMP-DX= 6.00 $$ some library\n##DATA TYPE= Shape Data\n##END=\n")
+
+    with pytest.raises(JcampdxVersionError):
+        JCAMPDX(path)

--- a/test/test_jcampdx.py
+++ b/test/test_jcampdx.py
@@ -50,13 +50,7 @@ def test_jcampdx(test_jcampdx_data):
 
 def test_jcampdx_iteration_and_length_follow_its_mapping_interface(tmp_path):
     path = tmp_path / "visu_pars"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$VisuCoreDim=2\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$VisuCoreDim=2\n##END=\n")
     jcamp = JCAMPDX(path)
 
     assert list(jcamp) == list(jcamp.keys())
@@ -142,13 +136,7 @@ def test_parallel_lists_do_not_split_a_string_on_a_delimiter_it_contains():
 
 def test_jcampdx_get_value_keeps_the_whole_enum_display_name(tmp_path):
     path = tmp_path / "configscan"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$CONFIG_SCAN_operation_mode=(operation, <[1H] TX Volume, RX Surface Array>)\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$CONFIG_SCAN_operation_mode=(operation, <[1H] TX Volume, RX Surface Array>)\n##END=\n")
 
     assert JCAMPDX(path).get_value("CONFIG_SCAN_operation_mode") == [
         "operation",
@@ -179,15 +167,7 @@ def test_run_length_expansion_handles_multiple_and_nested_runs():
 
 def test_jcampdx_data_parameter_parses_multiline_xy_pairs(tmp_path):
     path = tmp_path / "data"
-    path.write_text(
-        "##TITLE=XY Data\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$POINTS=(XY..XY)\n"
-        "1.0, 2.0\n"
-        "3.0, 4.0\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=XY Data\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$POINTS=(XY..XY)\n1.0, 2.0\n3.0, 4.0\n##END=\n")
 
     assert np.array_equal(
         JCAMPDX(path).get_value("POINTS"),
@@ -197,15 +177,7 @@ def test_jcampdx_data_parameter_parses_multiline_xy_pairs(tmp_path):
 
 def test_jcampdx_float_and_list_serialization_round_trip(tmp_path):
     source = tmp_path / "source"
-    source.write_text(
-        "##TITLE=Serialization Test\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$FLOAT=0.0\n"
-        "##$VALUES=( 2 )\n"
-        "0.0 0.0\n"
-        "##END=\n"
-    )
+    source.write_text("##TITLE=Serialization Test\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$FLOAT=0.0\n##$VALUES=( 2 )\n0.0 0.0\n##END=\n")
     jcamp = JCAMPDX(source)
 
     jcamp.get_parameter("FLOAT").value = 1.25
@@ -222,15 +194,7 @@ def test_jcampdx_float_and_list_serialization_round_trip(tmp_path):
 
 def test_jcampdx_data_parameter_setter_round_trip(tmp_path):
     source = tmp_path / "source-data"
-    source.write_text(
-        "##TITLE=XY Data\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$POINTS=(XY..XY)\n"
-        "1.0, 2.0\n"
-        "3.0, 4.0\n"
-        "##END=\n"
-    )
+    source.write_text("##TITLE=XY Data\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$POINTS=(XY..XY)\n1.0, 2.0\n3.0, 4.0\n##END=\n")
     jcamp = JCAMPDX(source)
     expected = np.array([[5.0, 6.0], [7.0, 8.0]])
 
@@ -337,18 +301,7 @@ def test_parse_value_does_not_treat_unclosed_parenthesis_as_list():
 
 def test_jcampdx_size_parsing_accepts_compact_and_padded_brackets(tmp_path):
     path = tmp_path / "sizes"
-    path.write_text(
-        "##TITLE=Size Test\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$COMPACT=(2)\n"
-        "1 2\n"
-        "##$PADDED=(   2   )\n"
-        "3 4\n"
-        "##$MATRIX=(2, 3)\n"
-        "1 2 3 4 5 6\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Size Test\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$COMPACT=(2)\n1 2\n##$PADDED=(   2   )\n3 4\n##$MATRIX=(2, 3)\n1 2 3 4 5 6\n##END=\n")
     jcamp = JCAMPDX(path)
 
     assert jcamp.get_parameter("COMPACT").size == (2,)
@@ -385,12 +338,7 @@ def test_jcampdx_detects_whitespace_padded_supported_versions(tmp_path, header, 
 
 def test_jcampdx_keeps_double_hash_inside_bracketed_value(tmp_path):
     path = tmp_path / "configscan"
-    path.write_text(
-        "##TITLE=Config Scan\n"
-        "##JCAMPDX= 5.0\n"
-        "##$PULPROG=<HpMode,On##$EndBis,04,FA#>\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Config Scan\n##JCAMPDX= 5.0\n##$PULPROG=<HpMode,On##$EndBis,04,FA#>\n##END=\n")
 
     assert JCAMPDX(path).get_value("PULPROG") == "HpMode,On##$EndBis,04,FA#"
 
@@ -402,13 +350,7 @@ def test_jcampdx_record_without_assignment_raises_typed_error():
 
 def test_load_parameter_allows_hash_and_dollar_in_value(tmp_path):
     path = tmp_path / "special-value"
-    path.write_text(
-        "##TITLE=Special Value\n"
-        "##JCAMPDX=5.0\n"
-        "##$VALUE=<cost $5 #tag>\n"
-        "##$NEXT=2\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Special Value\n##JCAMPDX=5.0\n##$VALUE=<cost $5 #tag>\n##$NEXT=2\n##END=\n")
 
     key, parameter = JCAMPDX.load_parameter(path, "VALUE")
 
@@ -444,16 +386,7 @@ def test_jcampdx_round_trip_preserves_comments_and_end_marker(tmp_path):
 
 def test_jcampdx_version_detection_is_label_based_within_header(tmp_path):
     path = tmp_path / "reordered-header"
-    path.write_text(
-        "##TITLE=Reordered Header\n"
-        "##DATATYPE=Parameter Values\n"
-        "##ORIGIN=Test\n"
-        "$$ header comment\n"
-        "##OWNER=Tester\n"
-        "##JCAMPDX=4.24\n"
-        "##$VALUE=42\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Reordered Header\n##DATATYPE=Parameter Values\n##ORIGIN=Test\n$$ header comment\n##OWNER=Tester\n##JCAMPDX=4.24\n##$VALUE=42\n##END=\n")
 
     jcamp = JCAMPDX(path)
 
@@ -491,15 +424,7 @@ def test_a_wrap_inside_a_string_does_not_invent_a_space(tmp_path):
 
 def test_a_wrap_at_a_space_keeps_exactly_one_space(tmp_path):
     path = tmp_path / "acqp"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$ACQ_size=( 4 )\n"
-        "128 64 \n"
-        "32 16\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$ACQ_size=( 4 )\n128 64 \n32 16\n##END=\n")
 
     assert np.array_equal(JCAMPDX(path)["ACQ_size"].value, np.array([128, 64, 32, 16]))
 
@@ -523,16 +448,7 @@ def test_write_does_not_wrap_comment_records(tmp_path):
     """
     comment = "$$ /opt/PV6.0.1/data/imag/20200913_160003_In_situ_experiment_with_a_very_long_name/74/acqp"
     path = tmp_path / "acqp"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##OWNER=imag\n"
-        f"{comment}\n"
-        "##$ACQ_size=( 2 )\n"
-        "128 64\n"
-        "##END=\n"
-    )
+    path.write_text(f"##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##OWNER=imag\n{comment}\n##$ACQ_size=( 2 )\n128 64\n##END=\n")
 
     original = JCAMPDX(path)
     original.write(tmp_path / "acqp.written")
@@ -654,15 +570,7 @@ def test_a_trailing_backslash_in_a_string_is_content_not_an_escape(tmp_path):
     would drop the record.
     """
     path = tmp_path / "visu_pars"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$VisuStudyDescription=( 2048 )\n"
-        "<\\\n"
-        ">\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$VisuStudyDescription=( 2048 )\n<\\\n>\n##END=\n")
 
     assert JCAMPDX(path)["VisuStudyDescription"].value == "\\"
 
@@ -675,13 +583,7 @@ def test_the_last_parameter_survives_a_file_without_an_end_marker(tmp_path):
     exception and no warning.
     """
     path = tmp_path / "visu_pars"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$VisuCoreDim=2\n"
-        "##$VisuRespSynchUsed=No\n"
-    )
+    path.write_text("##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$VisuCoreDim=2\n##$VisuRespSynchUsed=No\n")
 
     parameters = JCAMPDX(path)
 
@@ -693,16 +595,7 @@ def test_a_malformed_record_raises_a_typed_error(tmp_path):
     """Spec 2.3: an element count that does not fill the declared size is a
     diagnosable condition, not a raw numpy ValueError."""
     path = tmp_path / "acqp"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$SHORT=( 3, 3 )\n"
-        "1 2 3 4\n"
-        "##$BADSIZE=( a )\n"
-        "1 2\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$SHORT=( 3, 3 )\n1 2 3 4\n##$BADSIZE=( a )\n1 2\n##END=\n")
     parameters = JCAMPDX(path)
 
     with pytest.raises(InvalidJcampdxFile, match="do not fill the declared size"):

--- a/test/test_latent_conformance.py
+++ b/test/test_latent_conformance.py
@@ -218,15 +218,7 @@ def test_rawdata_settings_control_stored_scans_receivers_and_discarded_jobs(tmp_
 def test_a_dollar_comment_inside_a_string_is_data(tmp_path):
     """Spec 2.2: the text inside `<...>` is free-form, `$$` included."""
     path = tmp_path / "method"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$PVM_Comment=( 64 )\n"
-        "<a\n"
-        "$$b>\n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$PVM_Comment=( 64 )\n<a\n$$b>\n##END=\n")
 
     assert JCAMPDX(path)["PVM_Comment"].value == "a$$b"
 
@@ -235,12 +227,6 @@ def test_a_scalar_struct_is_not_eaten_as_a_size_bracket(tmp_path):
     """`##$VisuCoreSlicePacksDef=(0, 1)` is a value, not a size -- including when
     the line has a trailing blank."""
     path = tmp_path / "visu_pars"
-    path.write_text(
-        "##TITLE=Parameter List\n"
-        "##JCAMPDX=4.24\n"
-        "##DATATYPE=Parameter Values\n"
-        "##$VisuCoreSlicePacksDef=(0, 1) \n"
-        "##END=\n"
-    )
+    path.write_text("##TITLE=Parameter List\n##JCAMPDX=4.24\n##DATATYPE=Parameter Values\n##$VisuCoreSlicePacksDef=(0, 1) \n##END=\n")
 
     assert JCAMPDX(path)["VisuCoreSlicePacksDef"].value == [0, 1]

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -84,8 +84,7 @@ def test_dataset_reads_from_archive_identically(study_dir, study_zip):
 
 def test_parameters_resolve_through_relative_paths(study_dir, study_zip):
     """``../../acqp`` resolves inside an archive, where ``..`` is not collapsed."""
-    dataset = Dataset(study_zip / "1" / "pdata" / "1" / "2dseq", scale=False,
-                      parameter_files=["acqp"])
+    dataset = Dataset(study_zip / "1" / "pdata" / "1" / "2dseq", scale=False, parameter_files=["acqp"])
     assert dataset["ACQ_scan_name"].value == "demo"
 
 
@@ -111,7 +110,7 @@ def test_get_value_default_for_absent_key(study_dir):
 
 def test_path_helpers_work_for_both_kinds(study_dir, study_zip):
     assert isinstance(as_path(str(study_dir)), Path)
-    assert as_path(study_zip) is study_zip                        # passed through, not coerced
+    assert as_path(study_zip) is study_zip  # passed through, not coerced
 
     for root in (study_dir, study_zip):
         proc = root / "1" / "pdata" / "1"


### PR DESCRIPTION
Fixes #197.

Spec 2.1 makes `$$` a JCAMP-DX comment. `_detect_version` returned the whole line tail and compared it against a list of literals, so a real `spnam1` was rejected:

```
$ head -2 resources/testdata/pv7/full/20210128_122257_LEGO_PHANTOM_API_TEST_1_1/7/spnam1
##TITLE= /d/exp/stan/nmr/lists/wave/bp
##JCAMP-DX= 5.00 $$ BRUKER JCAMP library (alpha version)

JcampdxVersionError: "5.00 $$ BRUKER JCAMP library (alpha version)" is not a valid JCAMP-DX version
```

`Folder.make_tree` catches `JcampdxVersionError` and drops the child, so through a `Folder` the file just vanished with no diagnostic. The whitelist already carried two library-identification strings rather than versions — the same problem, patched one spelling at a time.

### Change

`JCAMPDX.parse_version` cuts at `$$` and takes the first token. `_detect_version`, the loaded-parameter path in `version`, and `verify_version` all go through it, so `SUPPORTED_VERSIONS` becomes four version numbers.

After the fix both `spnam0` and `spnam1` in the PV6 and PV7 studies load and report `5.00`; `acqp` still reports `4.24`.

### Test

`test_the_version_record_is_read_as_a_version_not_as_a_whole_line` covers all five spellings observed across the corpus, and `test_an_unsupported_version_is_still_rejected` keeps the rejection path honest. Both build their file inline — no vendor data.

Suite: 2146 passed, 12 skipped.