### PR TITLE
Include PV360's CMN_study_ parameters in the subject metadata group

### DIFF
--- a/brukerapi/dataset.py
+++ b/brukerapi/dataset.py
@@ -244,7 +244,7 @@ METADATA_GROUPS = {
     "visu_series": (("VisuSeries",), ("VisuExperimentNumber", "VisuProcessingNumber")),
     "visu_equipment": ((), ("VisuManufacturer", "VisuAcqSoftwareVersion", "VisuInstitution", "VisuStation")),
     "visu_acq": (("VisuAcq", "VisuAcquisition"), ()),
-    "subject": (("SUBJECT_",), ()),
+    "subject": (("SUBJECT_", "CMN_study_"), ()),
 }
 
 # What "could not read this parameter file" looks like. FileNotFoundError is the

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -69,6 +69,22 @@ def test_metadata_groups_follow_the_specification(tmp_path):
     assert "uisition_protocol" not in metadata["visu_acq"]
 
 
+def test_subject_group_carries_the_pv360_study_level_cmn_parameters(tmp_path):
+    """PV360 writes two CMN_ parameters into `subject`, next to SUBJECT_study_*.
+
+    `CMN_study_use_ats` says whether the Animal Transport System was in use,
+    which shifts the coordinate origin; selecting the group by `SUBJECT_` alone
+    dropped it and `CMN_study_bed` silently.
+    """
+    root = tmp_path / "20200612_094625_study_1_1"
+    write_jcampdx(root / "subject", {"SUBJECT_id": ["<phantom>"], "SUBJECT_study_nr": 1, "CMN_study_use_ats": "Yes", "CMN_study_bed": ["<Rat bed>"]})
+    dataset = Dataset(write_2dseq(root / "8" / "pdata" / "1"), add_parameters=["subject"], load=LOAD_STAGES["properties"])
+
+    assert dataset.metadata["subject"]["id"] == "phantom"
+    assert dataset.metadata["subject"]["use_ats"] == "Yes"
+    assert dataset.metadata["subject"]["bed"] == "Rat bed"
+
+
 def test_metadata_reports_the_same_string_as_the_property_that_reads_it(tmp_path):
     """`subj_id` and `metadata` read VisuSubjectName; they must agree.
 


### PR DESCRIPTION
Fixes #217.

```python
"subject": (("SUBJECT_", "CMN_study_"), ()),
```

ParaVision 360 writes two `CMN_` parameters into the study's `subject` file next to `SUBJECT_study_operator` and `SUBJECT_study_instrument_position` (PV360 Programming & Administration Manual §3.5.2.2): `CMN_study_use_ats`, whether the Animal Transport System is used for the study, and `CMN_study_bed`, the name of the animal bed. With the ATS in use the coordinate origin is shifted, so a reader that wants to know which frame the geometry is in has to look at `CMN_study_use_ats` — and `metadata["subject"]`, and with it `report(add_parameters=["subject"])`, dropped both silently.

### Change

`CMN_study_` becomes a second prefix of the `subject` group; the two appear as `metadata["subject"]["use_ats"]` and `["bed"]`. The prefix is `CMN_study_` rather than `CMN_` on purpose: `metadata` scans every loaded parameter file, not just `subject`, and the study-level pair is the only `CMN_` content the subject file is known to carry. PV5.1 and PV6 write neither, so nothing changes for them.

### Test

`test_subject_group_carries_the_pv360_study_level_cmn_parameters` — a synthetic study whose `subject` carries `CMN_study_use_ats=Yes` and `CMN_study_bed`. Fails on master. The corpus cannot show the change: the PV360 standard dataset ships no study-level `subject` file.

Suite: 2251 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHhfFXMNZKMuPm3ppdzFXe
